### PR TITLE
Finalize blocks on confirmation depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+*.log

--- a/crates/sc-consensus-nakamoto/src/block_import.rs
+++ b/crates/sc-consensus-nakamoto/src/block_import.rs
@@ -267,10 +267,11 @@ where
 
 /// Result of the operation of importing a Bitcoin block.
 ///
-/// Same semantic with [`sc_consensus::ImportResult`] for including more information
-/// in the Imported variant.
+/// Same semantic with [`sc_consensus::ImportResult`] with additional information
+/// in the [`ImportStatus::Imported`] variant.
 #[derive(Debug, Clone)]
 pub enum ImportStatus {
+    /// Block was imported successfully.
     Imported {
         block_number: u32,
         block_hash: BlockHash,
@@ -287,6 +288,7 @@ pub enum ImportStatus {
 }
 
 impl ImportStatus {
+    /// Returns `true` if the import status is [`Self::UnknownParent`].
     pub fn is_unknown_parent(&self) -> bool {
         matches!(self, Self::UnknownParent)
     }

--- a/crates/subcoin-node/src/cli.rs
+++ b/crates/subcoin-node/src/cli.rs
@@ -60,6 +60,19 @@ pub fn run() -> sc_cli::Result<()> {
                     network: bitcoin::Network::Bitcoin,
                     config: &config,
                 })?;
+                task_manager.spawn_handle().spawn("finalizer", None, {
+                    let client = client.clone();
+                    let spawn_handle = task_manager.spawn_handle();
+                    let confirmation_depth = 6u32;
+                    // TODO: proper value
+                    let is_major_syncing = std::sync::Arc::new(true.into());
+                    subcoin_service::finalize_confirmed_blocks(
+                        client,
+                        spawn_handle,
+                        confirmation_depth,
+                        is_major_syncing,
+                    )
+                });
                 Ok((import_blocks_cmd.run(client, data_dir), task_manager))
             })
         }


### PR DESCRIPTION
Without the finalization, the memory usage could become extremely high when the chain grows to 220000+. With some investigation, I found that it's caused by `NonCanonicalOverlay` when creating the DB backend.