### PR TITLE
Introduce multiple block executor implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9186,6 +9186,7 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-nakamoto",
  "sc-executor",
+ "sc-fast-sync-backend",
  "sc-network",
  "sc-rpc",
  "sc-service",
@@ -9201,10 +9202,28 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-storage 19.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
  "sp-trie",
  "subcoin-primitives",
  "subcoin-runtime",
+ "subcoin-test-service",
+ "tempfile",
+ "tokio",
  "tracing",
+]
+
+[[package]]
+name = "subcoin-test-service"
+version = "0.1.0"
+dependencies = [
+ "bitcoin 0.32.2",
+ "sc-consensus-nakamoto",
+ "sc-service",
+ "serde_json",
+ "sp-keyring",
+ "subcoin-runtime",
+ "subcoin-service",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,25 +2526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-executive"
-version = "28.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "aquamarine",
- "frame-support",
- "frame-system",
- "frame-try-runtime",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
- "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
-]
-
-[[package]]
 name = "frame-metadata"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,21 +2535,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
-]
-
-[[package]]
-name = "frame-metadata-hash-extension"
-version = "0.1.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "array-bytes",
- "docify",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
 ]
 
 [[package]]
@@ -4533,20 +4499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merkleized-metadata"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
-dependencies = [
- "array-bytes",
- "blake3",
- "frame-metadata",
- "parity-scale-codec",
- "scale-decode",
- "scale-info",
-]
-
-[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5163,44 +5115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "pallet-authorship"
-version = "28.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
-]
-
-[[package]]
-name = "pallet-babe"
-version = "28.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authorship",
- "pallet-session",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-application-crypto",
- "sp-consensus-babe",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
-]
-
-[[package]]
 name = "pallet-balances"
 version = "28.0.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
@@ -5254,48 +5168,6 @@ dependencies = [
  "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
  "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
  "sp-version",
-]
-
-[[package]]
-name = "pallet-session"
-version = "28.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "frame-support",
- "frame-system",
- "impl-trait-for-tuples",
- "log",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-session",
- "sp-staking",
- "sp-state-machine",
- "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
- "sp-trie",
-]
-
-[[package]]
-name = "pallet-timestamp"
-version = "27.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-inherents",
- "sp-io",
- "sp-runtime",
- "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
- "sp-storage 19.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
- "sp-timestamp",
 ]
 
 [[package]]
@@ -7018,7 +6890,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
- "substrate-test-runtime",
+ "subcoin-runtime",
  "tracing",
 ]
 
@@ -7579,29 +7451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scale-bits"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
-dependencies = [
- "parity-scale-codec",
- "scale-type-resolver",
-]
-
-[[package]]
-name = "scale-decode"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
-dependencies = [
- "derive_more",
- "parity-scale-codec",
- "scale-bits",
- "scale-type-resolver",
- "smallvec",
-]
-
-[[package]]
 name = "scale-info"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7626,12 +7475,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "scale-type-resolver"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -8238,40 +8081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-aura"
-version = "0.32.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
- "sp-timestamp",
-]
-
-[[package]]
-name = "sp-consensus-babe"
-version = "0.32.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-consensus-slots",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-timestamp",
-]
-
-[[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
@@ -8286,17 +8095,6 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
-]
-
-[[package]]
-name = "sp-consensus-slots"
-version = "0.32.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-timestamp",
 ]
 
 [[package]]
@@ -8763,18 +8561,6 @@ dependencies = [
  "ref-cast",
  "serde",
  "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "26.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
- "thiserror",
 ]
 
 [[package]]
@@ -9276,70 +9062,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-test-runtime"
-version = "2.0.0"
-source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
-dependencies = [
- "array-bytes",
- "frame-executive",
- "frame-metadata-hash-extension",
- "frame-support",
- "frame-system",
- "frame-system-rpc-runtime-api",
- "hex-literal",
- "log",
- "pallet-babe",
- "pallet-balances",
- "pallet-timestamp",
- "parity-scale-codec",
- "sc-service",
- "scale-info",
- "serde_json",
- "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-babe",
- "sp-consensus-grandpa",
- "sp-core",
- "sp-crypto-hashing",
- "sp-externalities 0.25.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-io",
- "sp-keyring",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-state-machine",
- "sp-transaction-pool",
- "sp-trie",
- "sp-version",
- "substrate-wasm-builder",
- "trie-db",
-]
-
-[[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
 dependencies = [
- "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata",
- "merkleized-metadata",
- "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
- "sc-executor",
- "sp-core",
- "sp-io",
  "sp-maybe-compressed-blob",
- "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
- "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.14",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,6 +2526,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-executive"
+version = "28.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "aquamarine",
+ "frame-support",
+ "frame-system",
+ "frame-try-runtime",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+]
+
+[[package]]
 name = "frame-metadata"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2554,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+]
+
+[[package]]
+name = "frame-metadata-hash-extension"
+version = "0.1.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "array-bytes",
+ "docify",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4499,6 +4533,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5115,6 +5163,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pallet-authorship"
+version = "28.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+]
+
+[[package]]
+name = "pallet-babe"
+version = "28.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+]
+
+[[package]]
 name = "pallet-balances"
 version = "28.0.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
@@ -5168,6 +5254,48 @@ dependencies = [
  "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
  "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
  "sp-version",
+]
+
+[[package]]
+name = "pallet-session"
+version = "28.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-trie",
+]
+
+[[package]]
+name = "pallet-timestamp"
+version = "27.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-storage 19.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -6880,6 +7008,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-fast-sync-backend"
+version = "0.1.0"
+dependencies = [
+ "parking_lot 0.12.3",
+ "sc-client-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+ "substrate-test-runtime",
+ "tracing",
+]
+
+[[package]]
 name = "sc-informant"
 version = "0.33.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
@@ -7436,6 +7579,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7460,6 +7626,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -8066,6 +8238,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-aura"
+version = "0.32.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+]
+
+[[package]]
+name = "sp-consensus-babe"
+version = "0.32.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
@@ -8080,6 +8286,17 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
+]
+
+[[package]]
+name = "sp-consensus-slots"
+version = "0.32.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-timestamp",
 ]
 
 [[package]]
@@ -8132,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -8194,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8214,7 +8431,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -8401,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -8433,7 +8650,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "Inflector",
  "expander",
@@ -8522,7 +8739,7 @@ source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 
 [[package]]
 name = "sp-storage"
@@ -8539,13 +8756,25 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
  "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "26.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "sp-inherents",
+ "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
@@ -8562,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -8659,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#221eddc90cd1efc4fc3c822ce5ccf289272fb41d"
+source = "git+https://github.com/paritytech/polkadot-sdk#e1460b5ee5f4490b428035aa4a72c1c99a262459"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -9028,17 +9257,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-test-runtime"
+version = "2.0.0"
+source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
+dependencies = [
+ "array-bytes",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "hex-literal",
+ "log",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sc-service",
+ "scale-info",
+ "serde_json",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities 0.25.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-state-machine",
+ "sp-transaction-pool",
+ "sp-trie",
+ "sp-version",
+ "substrate-wasm-builder",
+ "trie-db",
+]
+
+[[package]]
 name = "substrate-wasm-builder"
 version = "17.0.0"
 source = "git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin#c4a04f05a2d1c5e463385e74014d36a867d73adf"
 dependencies = [
+ "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
+ "sp-tracing 16.0.0 (git+https://github.com/liuchengxu/polkadot-sdk?branch=subcoin)",
+ "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/pallet-bitcoin",
     "crates/pallet-executive",
     "crates/sc-consensus-nakamoto",
+    "crates/sc-fast-sync-backend",
     "crates/subcoin-informant",
     "crates/subcoin-node",
     "crates/subcoin-primitives",
@@ -103,6 +104,7 @@ substrate-test-runtime = { git = "https://github.com/liuchengxu/polkadot-sdk", b
 pallet-bitcoin = { path = "crates/pallet-bitcoin", default-features = false }
 pallet-executive = { path = "crates/pallet-executive", default-features = false }
 sc-consensus-nakamoto = { path = "crates/sc-consensus-nakamoto" }
+sc-fast-sync-backend = { path = "crates/sc-fast-sync-backend" }
 subcoin-informant = { path = "crates/subcoin-informant" }
 subcoin-node = { path = "crates/subcoin-node" }
 subcoin-primitives = { path = "crates/subcoin-primitives" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ sp-version = { git = "https://github.com/liuchengxu/polkadot-sdk", branch = "sub
 substrate-build-script-utils = { git = "https://github.com/liuchengxu/polkadot-sdk", branch = "subcoin" }
 substrate-frame-rpc-system = { git = "https://github.com/liuchengxu/polkadot-sdk", branch = "subcoin" }
 substrate-wasm-builder = { git = "https://github.com/liuchengxu/polkadot-sdk", branch = "subcoin" }
-substrate-test-runtime = { git = "https://github.com/liuchengxu/polkadot-sdk", branch = "subcoin" }
 
 pallet-bitcoin = { path = "crates/pallet-bitcoin", default-features = false }
 pallet-executive = { path = "crates/pallet-executive", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/subcoin-runtime",
     "crates/subcoin-runtime-primitives",
     "crates/subcoin-service",
+    "crates/subcoin-test-service",
 ]
 
 default-members = ["crates/subcoin-node"]
@@ -111,6 +112,7 @@ subcoin-primitives = { path = "crates/subcoin-primitives" }
 subcoin-runtime = { path = "crates/subcoin-runtime" }
 subcoin-runtime-primitives = { path = "crates/subcoin-runtime-primitives", default-features = false }
 subcoin-service = { path = "crates/subcoin-service" }
+subcoin-test-service = { path = "crates/subcoin-test-service" }
 
 [profile.release]
 debug = true

--- a/crates/sc-consensus-nakamoto/src/block_executor.rs
+++ b/crates/sc-consensus-nakamoto/src/block_executor.rs
@@ -671,8 +671,7 @@ where
             .disk_runtime_block_executor
             .execute_block(parent_hash, block)?;
 
-        // FIXME
-        // assert_eq!(in_memory_state_root, state_root);
+        assert_eq!(in_memory_state_root, state_root);
 
         let in_memory_runtime_total = in_memory_runtime_exec_info.total();
         let in_memory_off_runtime_total = in_memory_off_runtime_exec_info.total();

--- a/crates/sc-consensus-nakamoto/src/block_executor.rs
+++ b/crates/sc-consensus-nakamoto/src/block_executor.rs
@@ -1,3 +1,16 @@
+use crate::verification::Coin;
+use async_trait::async_trait;
+use bitcoin::OutPoint;
+use sc_client_api::{AuxStore, Backend, BlockBackend, HeaderBackend, StorageProvider};
+use sc_consensus::{BlockImport, BlockImportParams, ImportResult, StateAction, StorageChanges};
+use sp_api::{ApiExt, CallApiAt, CallContext, Core, ProvideRuntimeApi};
+use sp_runtime::traits::{Block as BlockT, HashingFor, Header as HeaderT};
+use sp_state_machine::{StorageKey, StorageValue};
+use std::marker::PhantomData;
+use std::sync::Arc;
+use subcoin_primitives::runtime::Subcoin;
+use subcoin_primitives::{BitcoinTransactionAdapter, CoinStorageKey};
+
 /// A simply way to track the overall execution info for optimization purpose.
 #[derive(Debug, Default)]
 pub struct ExecutionInfo {
@@ -13,5 +26,719 @@ impl ExecutionInfo {
     /// Returns the total execution time in nanoseconds.
     pub fn total(&self) -> u128 {
         self.execute_block + self.fetch_state + self.into_storage_changes
+    }
+}
+
+/// Result of executing a new block.
+pub struct ExecuteBlockResult<Block: BlockT> {
+    /// New state root for the new block.
+    pub state_root: Block::Hash,
+    /// Storage changes for the new block.
+    pub storage_changes: sp_state_machine::StorageChanges<HashingFor<Block>>,
+    /// Execution informantion for performance tracking.
+    pub exec_info: ExecutionInfo,
+}
+
+/// Represents the state backend storage type for block execution.
+#[derive(Debug, Clone, Copy)]
+pub enum ExecutionBackend {
+    /// Disk backend.
+    Disk,
+    /// In memory backend.
+    InMemory,
+}
+
+/// Represents the different strategies for executing a block.
+#[derive(Debug, Clone, Copy)]
+pub enum BlockExecutionStrategy {
+    /// Executes the block using the runtime api `execute_block`,
+    RuntimeExecution(ExecutionBackend),
+    /// Executes the block without using the runtime api `execute_block`.
+    OffRuntimeExecution(ExecutionBackend),
+    /// Hybrid strategy combining both disk and in-memory runtime execution for performance comparison.
+    BenchmarkRuntimeExecution,
+    /// Benchmark all supported strategies.
+    ///
+    /// Check out the log for the performance details.
+    BenchmarkAll,
+}
+
+impl BlockExecutionStrategy {
+    pub fn runtime_disk() -> Self {
+        Self::RuntimeExecution(ExecutionBackend::Disk)
+    }
+
+    pub fn off_runtime_in_memory() -> Self {
+        Self::OffRuntimeExecution(ExecutionBackend::InMemory)
+    }
+
+    /// Returns `true` if the strategy makes use of the in memory backend.
+    pub fn in_memory_backend_used(&self) -> bool {
+        match self {
+            BlockExecutionStrategy::RuntimeExecution(exec_backend)
+            | BlockExecutionStrategy::OffRuntimeExecution(exec_backend) => {
+                matches!(exec_backend, ExecutionBackend::InMemory)
+            }
+            BlockExecutionStrategy::BenchmarkRuntimeExecution
+            | BlockExecutionStrategy::BenchmarkAll => true,
+        }
+    }
+}
+
+/// Trait for executing and importing the block.
+#[async_trait]
+pub trait BlockExecutor<Block: BlockT>: Send + Sync {
+    /// Returns the type of block execution strategy used.
+    fn execution_strategy(&self) -> BlockExecutionStrategy;
+
+    /// Executes the given block on top of the state specified by the parent hash.
+    fn execute_block(
+        &self,
+        parent_hash: Block::Hash,
+        block: Block,
+    ) -> sp_blockchain::Result<ExecuteBlockResult<Block>>;
+
+    /// Determines whether the block should be imported in the executor.
+    ///
+    /// `import_block` only makes sense for the executor using in memory backend.
+    fn is_in_memory_backend_used(&self) -> bool {
+        self.execution_strategy().in_memory_backend_used()
+    }
+
+    /// Imports the block using the given import params.
+    async fn import_block(
+        &mut self,
+        import_params: BlockImportParams<Block>,
+    ) -> Result<ImportResult, sp_consensus::Error>;
+}
+
+/// Backend type for the execution client.
+///
+/// The process of executing a block has been decoupled from the block import pipeline.
+/// There are two kinds of clients for executing the block:
+///
+/// 1) Client using the disk backend. This is the default behaviour in Substrate. The state
+/// is maintained in the disk backend and pruned according to the parameters provided on startup.
+///
+/// 2) Client using the in memory backend. This is specifically designated for fast block execution
+/// in the initial full sync stage, the in memory backend keeps the entire latest chain state in
+/// the memory for executing blocks, the previous states are not stored. The block executor using
+/// the in memory backend needs to import the block within the executor to update the in memory
+/// chain state.
+pub enum ClientContext<BI> {
+    Disk,
+    InMemory(BI),
+}
+
+impl<BI> std::fmt::Debug for ClientContext<BI> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disk => write!(f, "Disk"),
+            Self::InMemory(_) => write!(f, "InMemory"),
+        }
+    }
+}
+
+impl<BI> ClientContext<BI> {
+    pub fn execution_backend(&self) -> ExecutionBackend {
+        match self {
+            Self::Disk => ExecutionBackend::Disk,
+            Self::InMemory(_) => ExecutionBackend::InMemory,
+        }
+    }
+}
+
+/// Block executor using the runtime api `execute_block`.
+///
+/// This is the standard Substrate block executor.
+pub struct RuntimeBlockExecutor<Block, Client, BE, BI> {
+    client: Arc<Client>,
+    client_context: ClientContext<BI>,
+    _phantom: PhantomData<(Block, BE)>,
+}
+
+impl<Block, Client, BE, BI> RuntimeBlockExecutor<Block, Client, BE, BI> {
+    /// Constructs a new instance of [`RuntimeBlockExecutor`].
+    pub fn new(client: Arc<Client>, client_context: ClientContext<BI>) -> Self {
+        Self {
+            client,
+            client_context,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl<Block, BE, Client, BI> BlockExecutor<Block> for RuntimeBlockExecutor<Block, Client, BE, BI>
+where
+    Block: BlockT,
+    BE: Backend<Block>,
+    Client: HeaderBackend<Block>
+        + BlockBackend<Block>
+        + AuxStore
+        + ProvideRuntimeApi<Block>
+        + StorageProvider<Block, BE>
+        + CallApiAt<Block>,
+    Client::Api: Core<Block> + Subcoin<Block>,
+    BI: BlockImport<Block> + Send + Sync,
+{
+    fn execution_strategy(&self) -> BlockExecutionStrategy {
+        BlockExecutionStrategy::RuntimeExecution(self.client_context.execution_backend())
+    }
+
+    fn execute_block(
+        &self,
+        parent_hash: Block::Hash,
+        block: Block,
+    ) -> sp_blockchain::Result<ExecuteBlockResult<Block>> {
+        let mut runtime_api = self.client.runtime_api();
+        runtime_api.set_call_context(CallContext::Onchain);
+
+        let mut exec_info = ExecutionInfo::default();
+
+        let now = std::time::Instant::now();
+        runtime_api.execute_block_without_state_root_check(parent_hash, block)?;
+        exec_info.execute_block = now.elapsed().as_nanos();
+
+        let now = std::time::Instant::now();
+        let state = self.client.state_at(parent_hash)?;
+        exec_info.fetch_state = now.elapsed().as_nanos();
+
+        let now = std::time::Instant::now();
+        let storage_changes = runtime_api
+            .into_storage_changes(&state, parent_hash)
+            .map_err(sp_blockchain::Error::StorageChanges)?;
+        exec_info.into_storage_changes = now.elapsed().as_nanos();
+
+        let state_root = storage_changes.transaction_storage_root;
+
+        Ok(ExecuteBlockResult {
+            state_root,
+            storage_changes,
+            exec_info,
+        })
+    }
+
+    async fn import_block(
+        &mut self,
+        import_params: BlockImportParams<Block>,
+    ) -> Result<ImportResult, sp_consensus::Error> {
+        match &mut self.client_context {
+            ClientContext::InMemory(block_import) => block_import
+                .import_block(import_params)
+                .await
+                .map_err(|err| sp_consensus::Error::ClientImport(err.to_string())),
+            ClientContext::Disk => {
+                unreachable!("not needed for RuntimeBlockExecutor on disk backend");
+            }
+        }
+    }
+}
+
+/// Block executor using custom `apply_extrinsics`, for the initial sync process.
+pub struct OffRuntimeBlockExecutor<Block, Client, BE, TransactionAdapter, BI> {
+    client: Arc<Client>,
+    client_context: ClientContext<BI>,
+    coin_storage_key: Arc<dyn CoinStorageKey>,
+    _phantom: PhantomData<(Block, BE, TransactionAdapter)>,
+}
+
+impl<Block, Client, BE, TransactionAdapter, BI>
+    OffRuntimeBlockExecutor<Block, Client, BE, TransactionAdapter, BI>
+{
+    /// Constructs a new instance of [`OffRuntimeBlockExecutor`].
+    pub fn new(
+        client: Arc<Client>,
+        client_context: ClientContext<BI>,
+        coin_storage_key: Arc<dyn CoinStorageKey>,
+    ) -> Self {
+        Self {
+            client,
+            client_context,
+            coin_storage_key,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+type StorageEntry = (StorageKey, Option<StorageValue>);
+
+#[allow(unused)]
+fn execute_block_off_runtime<Block: BlockT>(
+    header: &<Block as BlockT>::Header,
+) -> Vec<StorageEntry> {
+    use hex_literal::hex;
+    use sp_core::Encode;
+
+    let number = header.number();
+    let parent_hash = header.parent_hash();
+    let digest = header.digest();
+    vec![
+        // Number<T>
+        (
+            hex!["26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac"].to_vec(),
+            Some(number.encode()),
+        ),
+        // ParentHash<T>
+        (
+            hex!["26aa394eea5630e07c48ae0c9558cef78a42f33323cb5ced3b44dd825fda9fcc"].to_vec(),
+            Some(parent_hash.encode()),
+        ),
+        // Digest<T>
+        (
+            hex!["26aa394eea5630e07c48ae0c9558cef799e7f93fc6a98f0874fd057f111c4d2d"].to_vec(),
+            Some(digest.encode()),
+        ),
+        // BlockWeight<T>
+        (
+            hex!["26aa394eea5630e07c48ae0c9558cef734abf5cb34d6244378cddbf18e849d96"].to_vec(),
+            None,
+        ),
+    ]
+    // Primarily apply_extrinsics()
+    //
+    // initialize() and finalize() are mostly for generating the header.
+    //
+    // Number<T>
+    // ParentHash<T>
+    // Digest<T>
+    // BlockHash<T> (parent_number, parent_hash)
+    //
+    // BlockWeight<T>: always None, as we delete `register_weight_unchecked` within `initialize()`.
+}
+
+fn apply_extrinsics_off_runtime<
+    Block: BlockT,
+    TransactionAdapter: BitcoinTransactionAdapter<Block>,
+>(
+    extrinsics: Vec<Block::Extrinsic>,
+    coin_storage_key: &Arc<dyn CoinStorageKey>,
+) -> Vec<(Vec<StorageEntry>, Option<u32>)> {
+    use codec::Encode;
+
+    extrinsics
+        .iter()
+        .enumerate()
+        .map(|(index, extrinsic)| {
+            let tx = TransactionAdapter::extrinsic_to_bitcoin_transaction(extrinsic);
+
+            let mut changes = Vec::with_capacity(tx.input.len() + tx.output.len());
+
+            for input in &tx.input {
+                let OutPoint { txid, vout } = input.previous_output;
+                let storage_key = coin_storage_key.storage_key(txid, vout);
+                changes.push((storage_key, None));
+            }
+
+            let txid = tx.compute_txid();
+            let is_coinbase = tx.is_coinbase();
+
+            for (index, txout) in tx.output.into_iter().enumerate() {
+                let storage_key = coin_storage_key.storage_key(txid, index as u32);
+                let coin = Coin {
+                    is_coinbase,
+                    amount: txout.value.to_sat(),
+                    script_pubkey: txout.script_pubkey.into_bytes(),
+                };
+
+                changes.push((storage_key, Some(coin.encode())));
+            }
+
+            (changes, Some(index as u32))
+        })
+        .collect()
+}
+
+fn format_time(nanoseconds: u128) -> String {
+    const NANOS_PER_MICRO: u128 = 1_000;
+    const NANOS_PER_MILLI: u128 = 1_000_000;
+    const NANOS_PER_SEC: u128 = 1_000_000_000;
+
+    if nanoseconds >= NANOS_PER_SEC {
+        let seconds = nanoseconds as f64 / NANOS_PER_SEC as f64;
+        format!("{:.2} s", seconds)
+    } else if nanoseconds >= NANOS_PER_MILLI {
+        let millis = nanoseconds as f64 / NANOS_PER_MILLI as f64;
+        format!("{:.2} ms", millis)
+    } else if nanoseconds >= NANOS_PER_MICRO {
+        let micros = nanoseconds as f64 / NANOS_PER_MICRO as f64;
+        format!("{:.2} µs", micros)
+    } else {
+        format!("{} ns", nanoseconds)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ExecuteBlockDetails {
+    /// initialize_block
+    pre: u128,
+    /// apply_extrinsics
+    apply: u128,
+    set_changes: u128,
+    /// post_extrinsics
+    post: u128,
+}
+
+#[async_trait]
+impl<Block, BE, Client, TransactionAdapter, BI> BlockExecutor<Block>
+    for OffRuntimeBlockExecutor<Block, Client, BE, TransactionAdapter, BI>
+where
+    Block: BlockT,
+    BE: Backend<Block>,
+    Client: HeaderBackend<Block>
+        + BlockBackend<Block>
+        + AuxStore
+        + ProvideRuntimeApi<Block>
+        + StorageProvider<Block, BE>
+        + CallApiAt<Block>,
+    Client::Api: Core<Block> + Subcoin<Block>,
+    TransactionAdapter: BitcoinTransactionAdapter<Block> + Send + Sync,
+    BI: BlockImport<Block> + Send + Sync + 'static,
+{
+    fn execution_strategy(&self) -> BlockExecutionStrategy {
+        BlockExecutionStrategy::OffRuntimeExecution(self.client_context.execution_backend())
+    }
+
+    fn execute_block(
+        &self,
+        parent_hash: Block::Hash,
+        block: Block,
+    ) -> sp_blockchain::Result<ExecuteBlockResult<Block>> {
+        let mut runtime_api = self.client.runtime_api();
+        runtime_api.set_call_context(CallContext::Onchain);
+
+        let (header, extrinsics) = block.deconstruct();
+
+        let mut exec_info = ExecutionInfo::default();
+
+        let now = std::time::Instant::now();
+
+        let mut exec_details = ExecuteBlockDetails::default();
+        let t = std::time::Instant::now();
+        runtime_api.initialize_block(parent_hash, &header)?;
+        exec_details.pre = t.elapsed().as_nanos();
+
+        let t = std::time::Instant::now();
+        let block_storage_changes = apply_extrinsics_off_runtime::<Block, TransactionAdapter>(
+            extrinsics,
+            &self.coin_storage_key,
+        );
+        exec_details.apply = t.elapsed().as_nanos();
+
+        // block_storage_changes.push((execute_block_off_runtime::<Block>(&header), None));
+
+        let t = std::time::Instant::now();
+        runtime_api
+            .changes_mut()
+            .borrow_mut()
+            .set_extrinsic_storage_changes(block_storage_changes);
+        exec_details.set_changes = t.elapsed().as_nanos();
+
+        let t = std::time::Instant::now();
+        runtime_api.finalize_block_without_checks(parent_hash, header)?;
+        exec_details.post = t.elapsed().as_nanos();
+
+        tracing::debug!("off_runtime({:?}): {exec_details:?}", self.client_context);
+
+        exec_info.execute_block = now.elapsed().as_nanos();
+
+        let now = std::time::Instant::now();
+        let state = self.client.state_at(parent_hash)?;
+        exec_info.fetch_state = now.elapsed().as_nanos();
+
+        let now = std::time::Instant::now();
+        let storage_changes = runtime_api
+            .into_storage_changes(&state, parent_hash)
+            .map_err(sp_blockchain::Error::StorageChanges)?;
+        exec_info.into_storage_changes = now.elapsed().as_nanos();
+
+        tracing::debug!(
+            "off_runtime({:?}): {exec_info:?}, total: {}",
+            self.client_context,
+            format_time(exec_info.total()),
+        );
+
+        let state_root = storage_changes.transaction_storage_root;
+
+        Ok(ExecuteBlockResult {
+            state_root,
+            storage_changes,
+            exec_info,
+        })
+    }
+
+    async fn import_block(
+        &mut self,
+        import_params: BlockImportParams<Block>,
+    ) -> Result<ImportResult, sp_consensus::Error> {
+        match &mut self.client_context {
+            ClientContext::InMemory(block_import) => block_import
+                .import_block(import_params)
+                .await
+                .map_err(|err| sp_consensus::Error::ClientImport(err.to_string())),
+            ClientContext::Disk => {
+                unreachable!("Not needed in disk backend context")
+            }
+        }
+    }
+}
+
+pub struct BenchmarkRuntimeBlockExecutor<Block: BlockT> {
+    disk_runtime_block_executor: Box<dyn BlockExecutor<Block>>,
+    in_memory_runtime_block_executor: Box<dyn BlockExecutor<Block>>,
+}
+
+impl<Block: BlockT> BenchmarkRuntimeBlockExecutor<Block> {
+    pub fn new(
+        disk_runtime_block_executor: Box<dyn BlockExecutor<Block>>,
+        in_memory_runtime_block_executor: Box<dyn BlockExecutor<Block>>,
+    ) -> Self {
+        Self {
+            disk_runtime_block_executor,
+            in_memory_runtime_block_executor,
+        }
+    }
+}
+
+#[async_trait]
+impl<Block: BlockT> BlockExecutor<Block> for BenchmarkRuntimeBlockExecutor<Block> {
+    fn execution_strategy(&self) -> BlockExecutionStrategy {
+        BlockExecutionStrategy::BenchmarkRuntimeExecution
+    }
+
+    fn execute_block(
+        &self,
+        parent_hash: Block::Hash,
+        block: Block,
+    ) -> sp_blockchain::Result<ExecuteBlockResult<Block>> {
+        tracing::debug!("============================================ In Memory Executor");
+        let ExecuteBlockResult {
+            state_root: in_memory_state_root,
+            storage_changes: _,
+            exec_info: in_memory_runtime_exec_info,
+        } = self
+            .in_memory_runtime_block_executor
+            .execute_block(parent_hash, block.clone())?;
+
+        tracing::debug!("============================================ Disk Executor");
+        let ExecuteBlockResult {
+            state_root,
+            storage_changes,
+            exec_info,
+        } = self
+            .disk_runtime_block_executor
+            .execute_block(parent_hash, block)?;
+
+        assert_eq!(in_memory_state_root, state_root);
+
+        let in_memory_runtime_total = in_memory_runtime_exec_info.total();
+        tracing::debug!(
+            "in_memory: {:?}, total: {in_memory_runtime_total}",
+            in_memory_runtime_exec_info
+        );
+        let disk_runtime_total = exec_info.total();
+        tracing::debug!(
+            "     disk: {:?}, total: {disk_runtime_total}, time (disk/in_memory): {:.2}x",
+            exec_info,
+            disk_runtime_total as f64 / in_memory_runtime_total as f64
+        );
+
+        Ok(ExecuteBlockResult {
+            state_root,
+            storage_changes,
+            exec_info,
+        })
+    }
+
+    async fn import_block(
+        &mut self,
+        import_params: BlockImportParams<Block>,
+    ) -> Result<ImportResult, sp_consensus::Error> {
+        self.in_memory_runtime_block_executor
+            .import_block(import_params)
+            .await
+            .map_err(|err| sp_consensus::Error::ClientImport(err.to_string()))
+    }
+}
+
+pub struct BenchmarkAllExecutor<
+    Block,
+    DiskRuntime,
+    InMemoryRuntime,
+    DiskOffRuntime,
+    InMemoryOffRuntime,
+> {
+    disk_runtime_block_executor: DiskRuntime,
+    in_memory_runtime_block_executor: InMemoryRuntime,
+    disk_off_runtime_block_executor: DiskOffRuntime,
+    in_memory_off_runtime_block_executor: InMemoryOffRuntime,
+    _phantom: PhantomData<Block>,
+}
+
+impl<Block, DiskRuntime, InMemoryRuntime, DiskOffRuntime, InMemoryOffRuntime>
+    BenchmarkAllExecutor<Block, DiskRuntime, InMemoryRuntime, DiskOffRuntime, InMemoryOffRuntime>
+{
+    pub fn new(
+        disk_runtime_block_executor: DiskRuntime,
+        in_memory_runtime_block_executor: InMemoryRuntime,
+        disk_off_runtime_block_executor: DiskOffRuntime,
+        in_memory_off_runtime_block_executor: InMemoryOffRuntime,
+    ) -> Self {
+        Self {
+            disk_runtime_block_executor,
+            in_memory_runtime_block_executor,
+            disk_off_runtime_block_executor,
+            in_memory_off_runtime_block_executor,
+            _phantom: Default::default(),
+        }
+    }
+}
+
+fn display_main_changes(changes: &[(Vec<u8>, Option<Vec<u8>>)]) -> String {
+    changes
+        .iter()
+        .map(|(key, value)| format!("{}, {value:?}", sp_core::hexdisplay::HexDisplay::from(key)))
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
+#[async_trait]
+impl<Block, DiskRuntime, InMemoryRuntime, DiskOffRuntime, InMemoryOffRuntime> BlockExecutor<Block>
+    for BenchmarkAllExecutor<
+        Block,
+        DiskRuntime,
+        InMemoryRuntime,
+        DiskOffRuntime,
+        InMemoryOffRuntime,
+    >
+where
+    Block: BlockT,
+    DiskRuntime: BlockExecutor<Block>,
+    InMemoryRuntime: BlockExecutor<Block>,
+    DiskOffRuntime: BlockExecutor<Block>,
+    InMemoryOffRuntime: BlockExecutor<Block>,
+{
+    fn execution_strategy(&self) -> BlockExecutionStrategy {
+        BlockExecutionStrategy::BenchmarkAll
+    }
+
+    fn execute_block(
+        &self,
+        parent_hash: Block::Hash,
+        block: Block,
+    ) -> sp_blockchain::Result<ExecuteBlockResult<Block>> {
+        let ExecuteBlockResult {
+            state_root: in_memory_state_root,
+            storage_changes: c1,
+            exec_info: in_memory_runtime_exec_info,
+        } = self
+            .in_memory_runtime_block_executor
+            .execute_block(parent_hash, block.clone())?;
+
+        let ExecuteBlockResult {
+            state_root: in_memory_off_runtime_state_root,
+            storage_changes: c2,
+            exec_info: in_memory_off_runtime_exec_info,
+        } = self
+            .in_memory_off_runtime_block_executor
+            .execute_block(parent_hash, block.clone())?;
+
+        if in_memory_state_root != in_memory_off_runtime_state_root {
+            tracing::debug!(
+                "    runtime changes: \n{}",
+                display_main_changes(&c1.main_storage_changes)
+            );
+            tracing::debug!(
+                "off_runtime changes: \n{}",
+                display_main_changes(&c2.main_storage_changes)
+            );
+            panic!("Off runtime state root does not match the runtime state root");
+        }
+
+        let ExecuteBlockResult {
+            state_root: _disk_off_runtime_state_root,
+            storage_changes: _,
+            exec_info: disk_off_runtime_exec_info,
+        } = self
+            .disk_off_runtime_block_executor
+            .execute_block(parent_hash, block.clone())?;
+
+        let ExecuteBlockResult {
+            state_root,
+            storage_changes,
+            exec_info: disk_runtime_exec_info,
+        } = self
+            .disk_runtime_block_executor
+            .execute_block(parent_hash, block)?;
+
+        // FIXME
+        // assert_eq!(in_memory_state_root, state_root);
+
+        let in_memory_runtime_total = in_memory_runtime_exec_info.total();
+        let in_memory_off_runtime_total = in_memory_off_runtime_exec_info.total();
+        let disk_off_runtime_total = disk_off_runtime_exec_info.total();
+        let disk_runtime_total = disk_runtime_exec_info.total();
+
+        let min_total = in_memory_runtime_total
+            .min(disk_off_runtime_total)
+            .min(in_memory_off_runtime_total)
+            .min(disk_runtime_total);
+
+        tracing::debug!(
+            "    runtime(in_memory): time (relative to min): {:.2}x, total: {in_memory_runtime_total}, {in_memory_runtime_exec_info:?}",
+            in_memory_runtime_total as f64 / min_total as f64
+        );
+        tracing::debug!(
+            "off_runtime(in_memory): time (relative to min): {:.2}x, total: {in_memory_off_runtime_total}, {in_memory_off_runtime_exec_info:?}",
+            in_memory_off_runtime_total as f64 / min_total as f64
+        );
+        tracing::debug!(
+            "     off_runtime(disk): time (relative to min): {:.2}x, total: {disk_off_runtime_total}, {disk_off_runtime_exec_info:?}",
+            disk_off_runtime_total as f64 / min_total as f64
+        );
+        tracing::debug!(
+            "         runtime(disk): time (relative to min): {:.2}x, total: {disk_runtime_total}, {disk_runtime_exec_info:?}",
+            disk_runtime_total as f64 / min_total as f64
+        );
+
+        Ok(ExecuteBlockResult {
+            state_root,
+            storage_changes,
+            exec_info: disk_runtime_exec_info,
+        })
+    }
+
+    async fn import_block(
+        &mut self,
+        import_params: BlockImportParams<Block>,
+    ) -> Result<ImportResult, sp_consensus::Error> {
+        let mut params = BlockImportParams::new(import_params.origin, import_params.header.clone());
+        params.post_digests.clone_from(&import_params.post_digests);
+        params.state_action = match &import_params.state_action {
+            StateAction::ApplyChanges(StorageChanges::<Block>::Changes(changes)) => {
+                StateAction::ApplyChanges(StorageChanges::<Block>::Changes(
+                    crate::block_import::clone_storage_changes::<Block>(changes),
+                ))
+            }
+            _ => unreachable!("Must be ApplyChanges"),
+        };
+        params
+            .auxiliary
+            .clone_from(&import_params.auxiliary.clone());
+        params.fork_choice = import_params.fork_choice;
+        params
+            .import_existing
+            .clone_from(&import_params.import_existing);
+        params.post_hash.clone_from(&import_params.post_hash);
+
+        self.in_memory_off_runtime_block_executor
+            .import_block(params)
+            .await
+            .map_err(|err| sp_consensus::Error::ClientImport(err.to_string()))?;
+
+        self.in_memory_runtime_block_executor
+            .import_block(import_params)
+            .await
+            .map_err(|err| sp_consensus::Error::ClientImport(err.to_string()))
     }
 }

--- a/crates/sc-consensus-nakamoto/src/lib.rs
+++ b/crates/sc-consensus-nakamoto/src/lib.rs
@@ -2,6 +2,10 @@ mod block_executor;
 mod block_import;
 mod verification;
 
+pub use block_executor::{
+    BenchmarkAllExecutor, BenchmarkRuntimeBlockExecutor, BlockExecutionStrategy, BlockExecutor,
+    ClientContext, ExecutionBackend, OffRuntimeBlockExecutor, RuntimeBlockExecutor,
+};
 pub use block_import::{BitcoinBlockImport, BitcoinBlockImporter, ImportConfig, ImportStatus};
 pub use verification::BlockVerification;
 

--- a/crates/sc-fast-sync-backend/Cargo.toml
+++ b/crates/sc-fast-sync-backend/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sc-fast-sync-backend"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+parking_lot = { workspace = true }
+sc-client-api = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-state-machine = { workspace = true }
+sp-trie = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+substrate-test-runtime = { workspace = true }

--- a/crates/sc-fast-sync-backend/Cargo.toml
+++ b/crates/sc-fast-sync-backend/Cargo.toml
@@ -17,4 +17,4 @@ sp-trie = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-substrate-test-runtime = { workspace = true }
+subcoin-runtime = { workspace = true }

--- a/crates/sc-fast-sync-backend/src/chain_state.rs
+++ b/crates/sc-fast-sync-backend/src/chain_state.rs
@@ -1,0 +1,266 @@
+use parking_lot::RwLock;
+use sp_core::storage::{well_known_keys, ChildInfo};
+use sp_runtime::traits::{Block as BlockT, HashingFor};
+use sp_runtime::StateVersion;
+use sp_state_machine::backend::AsTrieBackend;
+use sp_state_machine::{
+    Backend as StateBackend, BackendTransaction, ChildStorageCollection, InMemoryBackend, IterArgs,
+    StateMachineStats, StorageCollection, StorageIterator, StorageKey, StorageValue,
+};
+use sp_trie::{MerkleValue, PrefixedMemoryDB};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// A raw iterator over the `RefTrackingState`.
+pub struct RawIter<Block: BlockT> {
+    inner: <InMemoryBackend<HashingFor<Block>> as StateBackend<HashingFor<Block>>>::RawIter,
+}
+
+impl<Block: BlockT> StorageIterator<HashingFor<Block>> for RawIter<Block> {
+    type Backend = ChainState<Block>;
+    type Error = <ChainState<Block> as StateBackend<HashingFor<Block>>>::Error;
+
+    fn next_key(&mut self, backend: &Self::Backend) -> Option<Result<StorageKey, Self::Error>> {
+        self.inner.next_key(&backend.state.read())
+    }
+
+    fn next_pair(
+        &mut self,
+        backend: &Self::Backend,
+    ) -> Option<Result<(StorageKey, StorageValue), Self::Error>> {
+        self.inner.next_pair(&backend.state.read())
+    }
+
+    fn was_complete(&self) -> bool {
+        self.inner.was_complete()
+    }
+}
+
+/// Storage transactions are calculated as part of the `storage_root`.
+/// These transactions can be reused for importing the block into the
+/// storage. So, we cache them to not require a recomputation of those transactions.
+struct StorageTransactionCache<Block: BlockT> {
+    /// Contains the changes for the main and the child storages as one transaction.
+    transaction: BackendTransaction<HashingFor<Block>>,
+    /// The storage root after applying the transaction.
+    transaction_storage_root: Block::Hash,
+}
+
+impl<Block: BlockT> StorageTransactionCache<Block> {
+    fn into_inner(self) -> (Block::Hash, BackendTransaction<HashingFor<Block>>) {
+        (self.transaction_storage_root, self.transaction)
+    }
+}
+
+impl<Block: BlockT> Clone for StorageTransactionCache<Block> {
+    fn clone(&self) -> Self {
+        Self {
+            transaction: self.transaction.clone(),
+            transaction_storage_root: self.transaction_storage_root,
+        }
+    }
+}
+
+impl<Block: BlockT> core::fmt::Debug for StorageTransactionCache<Block> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut debug = f.debug_struct("StorageTransactionCache");
+
+        debug.field("transaction_storage_root", &self.transaction_storage_root);
+
+        debug.finish()
+    }
+}
+
+/// Latest state of subcoin, representing the state of UTXO set.
+#[derive(Debug, Clone)]
+pub struct ChainState<Block: BlockT> {
+    runtime_hash: Block::Hash,
+    runtime_code: Arc<Vec<u8>>,
+    pub(crate) state: Arc<RwLock<InMemoryBackend<HashingFor<Block>>>>,
+    read_storage_root_count: Arc<AtomicUsize>,
+    storage_transaction_cache: Arc<RwLock<Option<StorageTransactionCache<Block>>>>,
+}
+
+impl<Block: BlockT> ChainState<Block> {
+    pub fn new(runtime_hash: Block::Hash, runtime_code: Vec<u8>) -> Self {
+        Self {
+            runtime_hash,
+            runtime_code: Arc::new(runtime_code),
+            state: Arc::new(RwLock::new(Default::default())),
+            read_storage_root_count: Arc::new(AtomicUsize::new(0)),
+            storage_transaction_cache: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub fn reset_storage_root(&self) {
+        self.read_storage_root_count.store(0, Ordering::SeqCst);
+        *self.storage_transaction_cache.write() = None;
+    }
+
+    pub fn apply_transaction(
+        &mut self,
+        root: Block::Hash,
+        transaction: BackendTransaction<HashingFor<Block>>,
+    ) {
+        self.state.write().apply_transaction(root, transaction);
+    }
+}
+
+impl<B: BlockT> AsTrieBackend<HashingFor<B>> for ChainState<B> {
+    type TrieBackendStorage = PrefixedMemoryDB<HashingFor<B>>;
+
+    fn as_trie_backend(
+        &self,
+    ) -> &sp_state_machine::TrieBackend<Self::TrieBackendStorage, HashingFor<B>> {
+        unimplemented!(
+            "Implementing this trait is not easy for ChainState, \
+            but luckily it's not necessary for the block execution"
+        )
+    }
+}
+
+impl<Block: BlockT> StateBackend<HashingFor<Block>> for ChainState<Block> {
+    type Error = <InMemoryBackend<HashingFor<Block>> as StateBackend<HashingFor<Block>>>::Error;
+    type TrieBackendStorage =
+        <InMemoryBackend<HashingFor<Block>> as StateBackend<HashingFor<Block>>>::TrieBackendStorage;
+    type RawIter = RawIter<Block>;
+
+    fn storage(&self, key: &[u8]) -> Result<Option<StorageValue>, Self::Error> {
+        if key == well_known_keys::CODE {
+            return Ok(Some(self.runtime_code.to_vec()));
+        }
+
+        let now = std::time::Instant::now();
+        let res = self.state.read().storage(key);
+        tracing::debug!(target: "in_mem", "read {:?} took {}ns", 
+			sp_core::hexdisplay::HexDisplay::from(&key),
+            now.elapsed().as_nanos());
+        res
+    }
+
+    fn storage_hash(&self, key: &[u8]) -> Result<Option<Block::Hash>, Self::Error> {
+        if key == well_known_keys::CODE {
+            return Ok(Some(self.runtime_hash));
+        }
+
+        self.state.read().storage_hash(key)
+    }
+
+    fn closest_merkle_value(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<MerkleValue<Block::Hash>>, Self::Error> {
+        self.state.read().closest_merkle_value(key)
+    }
+
+    fn child_closest_merkle_value(
+        &self,
+        _child_info: &ChildInfo,
+        _key: &[u8],
+    ) -> Result<Option<MerkleValue<Block::Hash>>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn child_storage(
+        &self,
+        _child_info: &ChildInfo,
+        _key: &[u8],
+    ) -> Result<Option<StorageValue>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn child_storage_hash(
+        &self,
+        _child_info: &ChildInfo,
+        _key: &[u8],
+    ) -> Result<Option<Block::Hash>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn next_storage_key(&self, key: &[u8]) -> Result<Option<StorageKey>, Self::Error> {
+        self.state.read().next_storage_key(key)
+    }
+
+    fn next_child_storage_key(
+        &self,
+        _child_info: &ChildInfo,
+        _key: &[u8],
+    ) -> Result<Option<StorageKey>, Self::Error> {
+        unimplemented!()
+    }
+
+    fn storage_root<'a>(
+        &self,
+        delta: impl Iterator<Item = (&'a [u8], Option<&'a [u8]>)>,
+        state_version: StateVersion,
+    ) -> (Block::Hash, BackendTransaction<HashingFor<Block>>)
+    where
+        Block::Hash: Ord,
+    {
+        if let Some(cached) = self.storage_transaction_cache.read().as_ref() {
+            return cached.clone().into_inner();
+        }
+
+        let old = self.read_storage_root_count.fetch_add(1, Ordering::SeqCst);
+        let now = std::time::Instant::now();
+        let res = self.state.read().storage_root(delta, state_version);
+        // FIXME: there are two storage_root operations, but runtime disk has only one, figure it out
+        tracing::debug!(
+            "[in_mem::storage_root] storage_root: {}, elapsed {} ns, count: {}",
+            res.0,
+            now.elapsed().as_nanos(),
+            old + 1
+        );
+        let (transaction_storage_root, transaction) = res.clone();
+        *self.storage_transaction_cache.write() = Some(StorageTransactionCache {
+            transaction_storage_root,
+            transaction,
+        });
+        res
+    }
+
+    fn child_storage_root<'a>(
+        &self,
+        _child_info: &ChildInfo,
+        _delta: impl Iterator<Item = (&'a [u8], Option<&'a [u8]>)>,
+        _state_version: StateVersion,
+    ) -> (Block::Hash, bool, BackendTransaction<HashingFor<Block>>)
+    where
+        Block::Hash: Ord,
+    {
+        unimplemented!()
+    }
+
+    fn raw_iter(&self, args: IterArgs) -> Result<Self::RawIter, Self::Error> {
+        self.state
+            .read()
+            .raw_iter(args)
+            .map(|inner| RawIter { inner })
+    }
+
+    fn register_overlay_stats(&self, stats: &StateMachineStats) {
+        self.state.read().register_overlay_stats(stats)
+    }
+
+    fn usage_info(&self) -> sp_state_machine::UsageInfo {
+        sp_state_machine::UsageInfo::empty()
+    }
+
+    fn commit(
+        &self,
+        _: Block::Hash,
+        _: BackendTransaction<HashingFor<Block>>,
+        _: StorageCollection,
+        _: ChildStorageCollection,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    fn read_write_count(&self) -> (u32, u32, u32, u32) {
+        unimplemented!()
+    }
+
+    fn reset_read_write_count(&self) {
+        unimplemented!()
+    }
+}

--- a/crates/sc-fast-sync-backend/src/lib.rs
+++ b/crates/sc-fast-sync-backend/src/lib.rs
@@ -1,0 +1,989 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Fast-Sync Backend
+//!
+//! This is modified from the Substrate in memory backend, designated solely for
+//! executing the blocks efficiently in the memory during the initial sync.
+//! This backend only maintains the latest state of chain rather than the state history.
+
+mod chain_state;
+
+use chain_state::ChainState;
+use parking_lot::RwLock;
+use sc_client_api::backend::{self, NewBlockState};
+use sc_client_api::blockchain::{self, BlockStatus, HeaderBackend};
+use sc_client_api::leaves::LeafSet;
+use sc_client_api::UsageInfo;
+use sp_blockchain::{CachedHeaderMetadata, HeaderMetadata};
+use sp_core::offchain::storage::InMemOffchainStorage as OffchainStorage;
+use sp_core::storage::well_known_keys;
+use sp_runtime::generic::BlockId;
+use sp_runtime::traits::{Block as BlockT, HashingFor, Header as HeaderT, NumberFor, Zero};
+use sp_runtime::{Justification, Justifications, StateVersion, Storage};
+use sp_state_machine::{
+    Backend as StateBackend, BackendTransaction, ChildStorageCollection, InMemoryBackend,
+    IndexOperation, StorageCollection,
+};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct PendingBlock<B: BlockT> {
+    block: StoredBlock<B>,
+    state: NewBlockState,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+enum StoredBlock<B: BlockT> {
+    Header(B::Header, Option<Justifications>),
+    Full(B, Option<Justifications>),
+}
+
+impl<B: BlockT> StoredBlock<B> {
+    fn new(
+        header: B::Header,
+        body: Option<Vec<B::Extrinsic>>,
+        just: Option<Justifications>,
+    ) -> Self {
+        match body {
+            Some(body) => StoredBlock::Full(B::new(header, body), just),
+            None => StoredBlock::Header(header, just),
+        }
+    }
+
+    fn header(&self) -> &B::Header {
+        match *self {
+            StoredBlock::Header(ref h, _) => h,
+            StoredBlock::Full(ref b, _) => b.header(),
+        }
+    }
+
+    fn justifications(&self) -> Option<&Justifications> {
+        match *self {
+            StoredBlock::Header(_, ref j) | StoredBlock::Full(_, ref j) => j.as_ref(),
+        }
+    }
+
+    fn extrinsics(&self) -> Option<&[B::Extrinsic]> {
+        match *self {
+            StoredBlock::Header(_, _) => None,
+            StoredBlock::Full(ref b, _) => Some(b.extrinsics()),
+        }
+    }
+
+    fn into_inner(self) -> (B::Header, Option<Vec<B::Extrinsic>>, Option<Justifications>) {
+        match self {
+            StoredBlock::Header(header, just) => (header, None, just),
+            StoredBlock::Full(block, just) => {
+                let (header, body) = block.deconstruct();
+                (header, Some(body), just)
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct BlockchainStorage<Block: BlockT> {
+    blocks: HashMap<Block::Hash, StoredBlock<Block>>,
+    hashes: HashMap<NumberFor<Block>, Block::Hash>,
+    best_hash: Block::Hash,
+    best_number: NumberFor<Block>,
+    finalized_hash: Block::Hash,
+    finalized_number: NumberFor<Block>,
+    genesis_hash: Block::Hash,
+    header_cht_roots: HashMap<NumberFor<Block>, Block::Hash>,
+    leaves: LeafSet<Block::Hash, NumberFor<Block>>,
+    aux: HashMap<Vec<u8>, Vec<u8>>,
+}
+
+/// In-memory blockchain. Supports concurrent reads.
+#[derive(Clone)]
+pub struct Blockchain<Block: BlockT> {
+    storage: Arc<RwLock<BlockchainStorage<Block>>>,
+}
+
+impl<Block: BlockT> Default for Blockchain<Block> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Block: BlockT> Blockchain<Block> {
+    /// Get header hash of given block.
+    pub fn id(&self, id: BlockId<Block>) -> Option<Block::Hash> {
+        match id {
+            BlockId::Hash(h) => Some(h),
+            BlockId::Number(n) => self.storage.read().hashes.get(&n).cloned(),
+        }
+    }
+
+    pub fn best_hash(&self) -> Block::Hash {
+        self.storage.read().best_hash
+    }
+
+    /// Create new in-memory blockchain storage.
+    pub fn new() -> Blockchain<Block> {
+        let storage = Arc::new(RwLock::new(BlockchainStorage {
+            blocks: HashMap::new(),
+            hashes: HashMap::new(),
+            best_hash: Default::default(),
+            best_number: Zero::zero(),
+            finalized_hash: Default::default(),
+            finalized_number: Zero::zero(),
+            genesis_hash: Default::default(),
+            header_cht_roots: HashMap::new(),
+            leaves: LeafSet::new(),
+            aux: HashMap::new(),
+        }));
+        Blockchain { storage }
+    }
+
+    /// Insert a block header and associated data.
+    pub fn insert(
+        &self,
+        hash: Block::Hash,
+        header: <Block as BlockT>::Header,
+        justifications: Option<Justifications>,
+        body: Option<Vec<<Block as BlockT>::Extrinsic>>,
+        new_state: NewBlockState,
+    ) -> sp_blockchain::Result<()> {
+        let number = *header.number();
+        if new_state.is_best() {
+            self.apply_head(&header)?;
+        }
+
+        {
+            let mut storage = self.storage.write();
+            storage.leaves.import(hash, number, *header.parent_hash());
+            storage
+                .blocks
+                .insert(hash, StoredBlock::new(header, body, justifications));
+
+            if let NewBlockState::Final = new_state {
+                storage.finalized_hash = hash;
+                storage.finalized_number = number;
+            }
+
+            if number == Zero::zero() {
+                storage.genesis_hash = hash;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get total number of blocks.
+    pub fn blocks_count(&self) -> usize {
+        self.storage.read().blocks.len()
+    }
+
+    /// Compare this blockchain with another in-mem blockchain
+    pub fn equals_to(&self, other: &Self) -> bool {
+        // Check ptr equality first to avoid double read locks.
+        if std::ptr::eq(self, other) {
+            return true;
+        }
+        self.canon_equals_to(other) && self.storage.read().blocks == other.storage.read().blocks
+    }
+
+    /// Compare canonical chain to other canonical chain.
+    pub fn canon_equals_to(&self, other: &Self) -> bool {
+        // Check ptr equality first to avoid double read locks.
+        if std::ptr::eq(self, other) {
+            return true;
+        }
+        let this = self.storage.read();
+        let other = other.storage.read();
+        this.hashes == other.hashes
+            && this.best_hash == other.best_hash
+            && this.best_number == other.best_number
+            && this.genesis_hash == other.genesis_hash
+    }
+
+    /// Insert header CHT root.
+    pub fn insert_cht_root(&self, block: NumberFor<Block>, cht_root: Block::Hash) {
+        self.storage
+            .write()
+            .header_cht_roots
+            .insert(block, cht_root);
+    }
+
+    /// Set an existing block as head.
+    pub fn set_head(&self, hash: Block::Hash) -> sp_blockchain::Result<()> {
+        let header = self
+            .header(hash)?
+            .ok_or_else(|| sp_blockchain::Error::UnknownBlock(format!("{}", hash)))?;
+
+        self.apply_head(&header)
+    }
+
+    fn apply_head(&self, header: &<Block as BlockT>::Header) -> sp_blockchain::Result<()> {
+        let hash = header.hash();
+        let number = header.number();
+
+        // Note: this may lock storage, so it must happen before obtaining storage
+        // write lock.
+        let best_tree_route = {
+            let best_hash = self.storage.read().best_hash;
+            if &best_hash == header.parent_hash() {
+                None
+            } else {
+                let route = sp_blockchain::tree_route(self, best_hash, *header.parent_hash())?;
+                Some(route)
+            }
+        };
+
+        let mut storage = self.storage.write();
+
+        if let Some(tree_route) = best_tree_route {
+            // apply retraction and enaction when reorganizing up to parent hash
+            let enacted = tree_route.enacted();
+
+            for entry in enacted {
+                storage.hashes.insert(entry.number, entry.hash);
+            }
+
+            for entry in tree_route.retracted().iter().skip(enacted.len()) {
+                storage.hashes.remove(&entry.number);
+            }
+        }
+
+        storage.best_hash = hash;
+        storage.best_number = *number;
+        storage.hashes.insert(*number, hash);
+
+        Ok(())
+    }
+
+    fn finalize_header(
+        &self,
+        block: Block::Hash,
+        justification: Option<Justification>,
+    ) -> sp_blockchain::Result<()> {
+        let mut storage = self.storage.write();
+        storage.finalized_hash = block;
+
+        if justification.is_some() {
+            let block = storage
+                .blocks
+                .get_mut(&block)
+                .expect("hash was fetched from a block in the db; qed");
+
+            let block_justifications = match block {
+                StoredBlock::Header(_, ref mut j) | StoredBlock::Full(_, ref mut j) => j,
+            };
+
+            *block_justifications = justification.map(Justifications::from);
+        }
+
+        Ok(())
+    }
+
+    fn append_justification(
+        &self,
+        hash: Block::Hash,
+        justification: Justification,
+    ) -> sp_blockchain::Result<()> {
+        let mut storage = self.storage.write();
+
+        let block = storage
+            .blocks
+            .get_mut(&hash)
+            .expect("hash was fetched from a block in the db; qed");
+
+        let block_justifications = match block {
+            StoredBlock::Header(_, ref mut j) | StoredBlock::Full(_, ref mut j) => j,
+        };
+
+        if let Some(stored_justifications) = block_justifications {
+            if !stored_justifications.append(justification) {
+                return Err(sp_blockchain::Error::BadJustification(
+                    "Duplicate consensus engine ID".into(),
+                ));
+            }
+        } else {
+            *block_justifications = Some(Justifications::from(justification));
+        };
+
+        Ok(())
+    }
+
+    fn write_aux(&self, ops: Vec<(Vec<u8>, Option<Vec<u8>>)>) {
+        let mut storage = self.storage.write();
+        for (k, v) in ops {
+            match v {
+                Some(v) => storage.aux.insert(k, v),
+                None => storage.aux.remove(&k),
+            };
+        }
+    }
+}
+
+impl<Block: BlockT> HeaderBackend<Block> for Blockchain<Block> {
+    fn header(
+        &self,
+        hash: Block::Hash,
+    ) -> sp_blockchain::Result<Option<<Block as BlockT>::Header>> {
+        Ok(self
+            .storage
+            .read()
+            .blocks
+            .get(&hash)
+            .map(|b| b.header().clone()))
+    }
+
+    fn info(&self) -> blockchain::Info<Block> {
+        let storage = self.storage.read();
+        blockchain::Info {
+            best_hash: storage.best_hash,
+            best_number: storage.best_number,
+            genesis_hash: storage.genesis_hash,
+            finalized_hash: storage.finalized_hash,
+            finalized_number: storage.finalized_number,
+            finalized_state: if storage.finalized_hash != Default::default() {
+                Some((storage.finalized_hash, storage.finalized_number))
+            } else {
+                None
+            },
+            number_leaves: storage.leaves.count(),
+            block_gap: None,
+        }
+    }
+
+    fn status(&self, hash: Block::Hash) -> sp_blockchain::Result<BlockStatus> {
+        match self.storage.read().blocks.contains_key(&hash) {
+            true => Ok(BlockStatus::InChain),
+            false => Ok(BlockStatus::Unknown),
+        }
+    }
+
+    fn number(&self, hash: Block::Hash) -> sp_blockchain::Result<Option<NumberFor<Block>>> {
+        Ok(self
+            .storage
+            .read()
+            .blocks
+            .get(&hash)
+            .map(|b| *b.header().number()))
+    }
+
+    fn hash(
+        &self,
+        number: <<Block as BlockT>::Header as HeaderT>::Number,
+    ) -> sp_blockchain::Result<Option<Block::Hash>> {
+        Ok(self.id(BlockId::Number(number)))
+    }
+}
+
+impl<Block: BlockT> HeaderMetadata<Block> for Blockchain<Block> {
+    type Error = sp_blockchain::Error;
+
+    fn header_metadata(
+        &self,
+        hash: Block::Hash,
+    ) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
+        self.header(hash)?
+            .map(|header| CachedHeaderMetadata::from(&header))
+            .ok_or_else(|| {
+                sp_blockchain::Error::UnknownBlock(format!(
+                    "[header_metadata] header not found: {}",
+                    hash
+                ))
+            })
+    }
+
+    fn insert_header_metadata(&self, _hash: Block::Hash, _metadata: CachedHeaderMetadata<Block>) {
+        // No need to implement.
+    }
+    fn remove_header_metadata(&self, _hash: Block::Hash) {
+        // No need to implement.
+    }
+}
+
+impl<Block: BlockT> blockchain::Backend<Block> for Blockchain<Block> {
+    fn body(
+        &self,
+        hash: Block::Hash,
+    ) -> sp_blockchain::Result<Option<Vec<<Block as BlockT>::Extrinsic>>> {
+        Ok(self
+            .storage
+            .read()
+            .blocks
+            .get(&hash)
+            .and_then(|b| b.extrinsics().map(|x| x.to_vec())))
+    }
+
+    fn justifications(&self, hash: Block::Hash) -> sp_blockchain::Result<Option<Justifications>> {
+        Ok(self
+            .storage
+            .read()
+            .blocks
+            .get(&hash)
+            .and_then(|b| b.justifications().cloned()))
+    }
+
+    fn last_finalized(&self) -> sp_blockchain::Result<Block::Hash> {
+        Ok(self.storage.read().finalized_hash)
+    }
+
+    fn leaves(&self) -> sp_blockchain::Result<Vec<Block::Hash>> {
+        Ok(self.storage.read().leaves.hashes())
+    }
+
+    fn displaced_leaves_after_finalizing(
+        &self,
+        _finalized_block_hash: Block::Hash,
+        _finalized_block_number: NumberFor<Block>,
+    ) -> sp_blockchain::Result<sp_blockchain::DisplacedLeavesAfterFinalization<Block>> {
+        unimplemented!("Not supported by the in-mem backend.")
+    }
+
+    fn children(&self, _parent_hash: Block::Hash) -> sp_blockchain::Result<Vec<Block::Hash>> {
+        unimplemented!()
+    }
+
+    fn indexed_transaction(&self, _hash: Block::Hash) -> sp_blockchain::Result<Option<Vec<u8>>> {
+        unimplemented!("Not supported by the in-mem backend.")
+    }
+
+    fn block_indexed_body(
+        &self,
+        _hash: Block::Hash,
+    ) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>> {
+        unimplemented!("Not supported by the in-mem backend.")
+    }
+}
+
+impl<Block: BlockT> backend::AuxStore for Blockchain<Block> {
+    fn insert_aux<
+        'a,
+        'b: 'a,
+        'c: 'a,
+        I: IntoIterator<Item = &'a (&'c [u8], &'c [u8])>,
+        D: IntoIterator<Item = &'a &'b [u8]>,
+    >(
+        &self,
+        insert: I,
+        delete: D,
+    ) -> sp_blockchain::Result<()> {
+        let mut storage = self.storage.write();
+        for (k, v) in insert {
+            storage.aux.insert(k.to_vec(), v.to_vec());
+        }
+        for k in delete {
+            storage.aux.remove(*k);
+        }
+        Ok(())
+    }
+
+    fn get_aux(&self, key: &[u8]) -> sp_blockchain::Result<Option<Vec<u8>>> {
+        Ok(self.storage.read().aux.get(key).cloned())
+    }
+}
+
+/// In-memory operation.
+pub struct BlockImportOperation<Block: BlockT> {
+    pending_block: Option<PendingBlock<Block>>,
+    old_state: ChainState<Block>,
+    /// Delta changes needed to create new state for the new block.
+    db_updates: Option<BackendTransaction<HashingFor<Block>>>,
+    aux: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+    finalized_blocks: Vec<(Block::Hash, Option<Justification>)>,
+    set_head: Option<Block::Hash>,
+}
+
+impl<Block: BlockT> BlockImportOperation<Block> {
+    fn apply_storage(
+        &mut self,
+        storage: Storage,
+        commit: bool,
+        state_version: StateVersion,
+    ) -> sp_blockchain::Result<Block::Hash> {
+        check_genesis_storage(&storage)?;
+
+        let child_delta = storage.children_default.values().map(|child_content| {
+            (
+                &child_content.child_info,
+                child_content
+                    .data
+                    .iter()
+                    .map(|(k, v)| (k.as_ref(), Some(v.as_ref()))),
+            )
+        });
+
+        let (root, transaction) = self.old_state.state.read().full_storage_root(
+            storage
+                .top
+                .iter()
+                .map(|(k, v)| (k.as_ref(), Some(v.as_ref()))),
+            child_delta,
+            state_version,
+        );
+
+        if commit {
+            self.db_updates = Some(transaction);
+        }
+
+        Ok(root)
+    }
+}
+
+impl<Block: BlockT> backend::BlockImportOperation<Block> for BlockImportOperation<Block> {
+    type State = ChainState<Block>;
+
+    fn state(&self) -> sp_blockchain::Result<Option<&Self::State>> {
+        Ok(Some(&self.old_state))
+    }
+
+    fn set_block_data(
+        &mut self,
+        header: <Block as BlockT>::Header,
+        body: Option<Vec<<Block as BlockT>::Extrinsic>>,
+        _indexed_body: Option<Vec<Vec<u8>>>,
+        justifications: Option<Justifications>,
+        state: NewBlockState,
+    ) -> sp_blockchain::Result<()> {
+        assert!(
+            self.pending_block.is_none(),
+            "Only one block per operation is allowed"
+        );
+        self.pending_block = Some(PendingBlock {
+            block: StoredBlock::new(header, body, justifications),
+            state,
+        });
+        Ok(())
+    }
+
+    fn update_db_storage(
+        &mut self,
+        update: BackendTransaction<HashingFor<Block>>,
+    ) -> sp_blockchain::Result<()> {
+        self.db_updates = Some(update);
+        Ok(())
+    }
+
+    fn set_genesis_state(
+        &mut self,
+        storage: Storage,
+        commit: bool,
+        state_version: StateVersion,
+    ) -> sp_blockchain::Result<Block::Hash> {
+        self.apply_storage(storage, commit, state_version)
+    }
+
+    fn reset_storage(
+        &mut self,
+        storage: Storage,
+        state_version: StateVersion,
+    ) -> sp_blockchain::Result<Block::Hash> {
+        self.apply_storage(storage, true, state_version)
+    }
+
+    fn insert_aux<I>(&mut self, ops: I) -> sp_blockchain::Result<()>
+    where
+        I: IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
+    {
+        self.aux.append(&mut ops.into_iter().collect());
+        Ok(())
+    }
+
+    fn update_storage(
+        &mut self,
+        _update: StorageCollection,
+        _child_update: ChildStorageCollection,
+    ) -> sp_blockchain::Result<()> {
+        Ok(())
+    }
+
+    fn mark_finalized(
+        &mut self,
+        hash: Block::Hash,
+        justification: Option<Justification>,
+    ) -> sp_blockchain::Result<()> {
+        self.finalized_blocks.push((hash, justification));
+        Ok(())
+    }
+
+    fn mark_head(&mut self, hash: Block::Hash) -> sp_blockchain::Result<()> {
+        assert!(
+            self.pending_block.is_none(),
+            "Only one set block per operation is allowed"
+        );
+        self.set_head = Some(hash);
+        Ok(())
+    }
+
+    fn update_transaction_index(
+        &mut self,
+        _index: Vec<IndexOperation>,
+    ) -> sp_blockchain::Result<()> {
+        Ok(())
+    }
+}
+
+/// In-memory backend. Keeps the latest state in memory.
+///
+/// > **Warning**: Doesn't support all the features necessary for a proper database. Only use this
+/// > struct for the fast sync purposes. Do **NOT** use in production.
+pub struct Backend<Block: BlockT> {
+    chain_state: ChainState<Block>,
+    blockchain: Blockchain<Block>,
+    import_lock: RwLock<()>,
+    pinned_blocks: RwLock<HashMap<Block::Hash, i64>>,
+}
+
+impl<Block: BlockT> Backend<Block> {
+    /// Create a new instance of in-mem backend for the fast sync purpose.
+    pub fn new(runtime_hash: Block::Hash, runtime_code: Vec<u8>) -> Self {
+        Self {
+            blockchain: Blockchain::new(),
+            chain_state: ChainState::new(runtime_hash, runtime_code),
+            import_lock: Default::default(),
+            pinned_blocks: Default::default(),
+        }
+    }
+
+    /// Initialize the blockchain storage and chain state.
+    pub fn initialize(
+        &mut self,
+        best_header: Block::Header,
+        genesis_hash: Block::Hash,
+        state: InMemoryBackend<HashingFor<Block>>,
+    ) {
+        {
+            let hash = best_header.hash();
+            let number = *best_header.number();
+
+            let mut storage = self.blockchain.storage.write();
+            storage.best_hash = hash;
+            storage.best_number = number;
+            storage.hashes.insert(number, hash);
+            storage.genesis_hash = genesis_hash;
+
+            storage
+                .leaves
+                .import(hash, number, *best_header.parent_hash());
+            storage
+                .blocks
+                .insert(hash, StoredBlock::new(best_header, None, None));
+        }
+
+        *self.chain_state.state.write() = state;
+    }
+
+    pub fn storage_root(&self) -> Block::Hash {
+        *self.chain_state.state.read().root()
+    }
+
+    /// Return the number of references active for a pinned block.
+    ///
+    /// # Warning
+    ///
+    /// For testing purposes only!
+    pub fn pin_refs(&self, hash: &<Block as BlockT>::Hash) -> Option<i64> {
+        let blocks = self.pinned_blocks.read();
+        blocks.get(hash).copied()
+    }
+}
+
+impl<Block: BlockT> backend::AuxStore for Backend<Block> {
+    fn insert_aux<
+        'a,
+        'b: 'a,
+        'c: 'a,
+        I: IntoIterator<Item = &'a (&'c [u8], &'c [u8])>,
+        D: IntoIterator<Item = &'a &'b [u8]>,
+    >(
+        &self,
+        insert: I,
+        delete: D,
+    ) -> sp_blockchain::Result<()> {
+        self.blockchain.insert_aux(insert, delete)
+    }
+
+    fn get_aux(&self, key: &[u8]) -> sp_blockchain::Result<Option<Vec<u8>>> {
+        self.blockchain.get_aux(key)
+    }
+}
+
+impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
+    type BlockImportOperation = BlockImportOperation<Block>;
+    type Blockchain = Blockchain<Block>;
+    type State = ChainState<Block>;
+    type OffchainStorage = OffchainStorage;
+
+    fn begin_operation(&self) -> sp_blockchain::Result<Self::BlockImportOperation> {
+        let old_state = self.state_at(Default::default())?;
+        self.chain_state.reset_storage_root();
+        Ok(BlockImportOperation {
+            pending_block: None,
+            old_state,
+            db_updates: None,
+            aux: Default::default(),
+            finalized_blocks: Default::default(),
+            set_head: None,
+        })
+    }
+
+    fn begin_state_operation(
+        &self,
+        operation: &mut Self::BlockImportOperation,
+        block: Block::Hash,
+    ) -> sp_blockchain::Result<()> {
+        operation.old_state = self.state_at(block)?;
+        Ok(())
+    }
+
+    // Writes the storage changes in the new block to the backend.
+    fn commit_operation(&self, operation: Self::BlockImportOperation) -> sp_blockchain::Result<()> {
+        if !operation.finalized_blocks.is_empty() {
+            for (block, justification) in operation.finalized_blocks {
+                self.blockchain.finalize_header(block, justification)?;
+            }
+        }
+
+        if let Some(pending_block) = operation.pending_block {
+            let (header, body, justification) = pending_block.block.into_inner();
+
+            let hash = header.hash();
+
+            // Calculate the new state.
+            if let Some(state) = operation.db_updates {
+                self.chain_state
+                    .state
+                    .write()
+                    .apply_transaction(*header.state_root(), state);
+            }
+
+            self.blockchain
+                .insert(hash, header, justification, body, pending_block.state)?;
+        }
+
+        if !operation.aux.is_empty() {
+            self.blockchain.write_aux(operation.aux);
+        }
+
+        if let Some(set_head) = operation.set_head {
+            self.blockchain.set_head(set_head)?;
+        }
+
+        Ok(())
+    }
+
+    fn finalize_block(
+        &self,
+        hash: Block::Hash,
+        justification: Option<Justification>,
+    ) -> sp_blockchain::Result<()> {
+        self.blockchain.finalize_header(hash, justification)
+    }
+
+    fn append_justification(
+        &self,
+        hash: Block::Hash,
+        justification: Justification,
+    ) -> sp_blockchain::Result<()> {
+        self.blockchain.append_justification(hash, justification)
+    }
+
+    fn blockchain(&self) -> &Self::Blockchain {
+        &self.blockchain
+    }
+
+    fn usage_info(&self) -> Option<UsageInfo> {
+        None
+    }
+
+    fn offchain_storage(&self) -> Option<Self::OffchainStorage> {
+        unimplemented!("Not supported by the fast-sync backend")
+    }
+
+    fn state_at(&self, hash: Block::Hash) -> sp_blockchain::Result<Self::State> {
+        let best_hash = self.blockchain.best_hash();
+        if hash != best_hash {
+            // TODO: why so many requests at Hash::default()?
+            // tracing::error!(?best_hash, "Fetching state at {hash}");
+            // return Err(sp_blockchain::Error::StateDatabase(format!(
+            // "fast-sync backend only support fetching the state at the best block {best_hash}"
+            // )));
+        }
+
+        Ok(self.chain_state.clone())
+    }
+
+    fn revert(
+        &self,
+        _n: NumberFor<Block>,
+        _revert_finalized: bool,
+    ) -> sp_blockchain::Result<(NumberFor<Block>, HashSet<Block::Hash>)> {
+        unimplemented!("Not supported by the fast-sync backend")
+    }
+
+    fn remove_leaf_block(&self, _hash: Block::Hash) -> sp_blockchain::Result<()> {
+        Ok(())
+    }
+
+    fn get_import_lock(&self) -> &RwLock<()> {
+        &self.import_lock
+    }
+
+    fn requires_full_sync(&self) -> bool {
+        true
+    }
+
+    fn pin_block(&self, hash: <Block as BlockT>::Hash) -> blockchain::Result<()> {
+        let mut blocks = self.pinned_blocks.write();
+        *blocks.entry(hash).or_default() += 1;
+        Ok(())
+    }
+
+    fn unpin_block(&self, hash: <Block as BlockT>::Hash) {
+        let mut blocks = self.pinned_blocks.write();
+        blocks
+            .entry(hash)
+            .and_modify(|counter| *counter -= 1)
+            .or_insert(-1);
+    }
+}
+
+impl<Block: BlockT> backend::LocalBackend<Block> for Backend<Block> {}
+
+/// Check that genesis storage is valid.
+pub fn check_genesis_storage(storage: &Storage) -> sp_blockchain::Result<()> {
+    if storage
+        .top
+        .iter()
+        .any(|(k, _)| well_known_keys::is_child_storage_key(k))
+    {
+        return Err(sp_blockchain::Error::InvalidState);
+    }
+
+    if storage
+        .children_default
+        .keys()
+        .any(|child_key| !well_known_keys::is_child_storage_key(child_key))
+    {
+        return Err(sp_blockchain::Error::InvalidState);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sp_blockchain::Backend;
+    use sp_runtime::traits::Header as HeaderT;
+    use sp_runtime::{ConsensusEngineId, Justifications};
+    use substrate_test_runtime::{Block, Header, H256};
+
+    pub const ID1: ConsensusEngineId = *b"TST1";
+    pub const ID2: ConsensusEngineId = *b"TST2";
+
+    fn header(number: u64) -> Header {
+        let parent_hash = match number {
+            0 => Default::default(),
+            _ => header(number - 1).hash(),
+        };
+        Header::new(
+            number,
+            H256::from_low_u64_be(0),
+            H256::from_low_u64_be(0),
+            parent_hash,
+            Default::default(),
+        )
+    }
+
+    fn test_blockchain() -> Blockchain<Block> {
+        let blockchain = Blockchain::<Block>::new();
+        let just0 = Some(Justifications::from((ID1, vec![0])));
+        let just1 = Some(Justifications::from((ID1, vec![1])));
+        let just2 = None;
+        let just3 = Some(Justifications::from((ID1, vec![3])));
+        blockchain
+            .insert(
+                header(0).hash(),
+                header(0),
+                just0,
+                None,
+                NewBlockState::Final,
+            )
+            .unwrap();
+        blockchain
+            .insert(
+                header(1).hash(),
+                header(1),
+                just1,
+                None,
+                NewBlockState::Final,
+            )
+            .unwrap();
+        blockchain
+            .insert(
+                header(2).hash(),
+                header(2),
+                just2,
+                None,
+                NewBlockState::Best,
+            )
+            .unwrap();
+        blockchain
+            .insert(
+                header(3).hash(),
+                header(3),
+                just3,
+                None,
+                NewBlockState::Final,
+            )
+            .unwrap();
+        blockchain
+    }
+
+    #[test]
+    fn append_and_retrieve_justifications() {
+        let blockchain = test_blockchain();
+        let last_finalized = blockchain.last_finalized().unwrap();
+
+        blockchain
+            .append_justification(last_finalized, (ID2, vec![4]))
+            .unwrap();
+        let justifications = {
+            let mut just = Justifications::from((ID1, vec![3]));
+            just.append((ID2, vec![4]));
+            just
+        };
+        assert_eq!(
+            blockchain.justifications(last_finalized).unwrap(),
+            Some(justifications)
+        );
+    }
+
+    #[test]
+    fn store_duplicate_justifications_is_forbidden() {
+        let blockchain = test_blockchain();
+        let last_finalized = blockchain.last_finalized().unwrap();
+
+        blockchain
+            .append_justification(last_finalized, (ID2, vec![0]))
+            .unwrap();
+        assert!(matches!(
+            blockchain.append_justification(last_finalized, (ID2, vec![1])),
+            Err(sp_blockchain::Error::BadJustification(_)),
+        ));
+    }
+}

--- a/crates/sc-fast-sync-backend/src/lib.rs
+++ b/crates/sc-fast-sync-backend/src/lib.rs
@@ -888,14 +888,16 @@ pub fn check_genesis_storage(storage: &Storage) -> sp_blockchain::Result<()> {
 mod tests {
     use super::*;
     use sp_blockchain::Backend;
+    use sp_core::H256;
     use sp_runtime::traits::Header as HeaderT;
     use sp_runtime::{ConsensusEngineId, Justifications};
-    use substrate_test_runtime::{Block, Header, H256};
+    use subcoin_runtime::interface::OpaqueBlock as Block;
+    use subcoin_runtime::Header;
 
     pub const ID1: ConsensusEngineId = *b"TST1";
     pub const ID2: ConsensusEngineId = *b"TST2";
 
-    fn header(number: u64) -> Header {
+    fn header(number: u32) -> Header {
         let parent_hash = match number {
             0 => Default::default(),
             _ => header(number - 1).hash(),

--- a/crates/subcoin-node/src/cli.rs
+++ b/crates/subcoin-node/src/cli.rs
@@ -66,6 +66,7 @@ pub fn run() -> sc_cli::Result<()> {
 
     match command {
         Command::ImportBlocks(cmd) => {
+            let block_execution_strategy = cmd.common_params.block_execution_strategy();
             let import_blocks_cmd = ImportBlocksCmd::new(&cmd);
             let runner = SubstrateCli.create_runner(&import_blocks_cmd)?;
             let data_dir = cmd.data_dir;
@@ -73,10 +74,12 @@ pub fn run() -> sc_cli::Result<()> {
                 let subcoin_service::NodeComponents {
                     client,
                     task_manager,
+                    block_executor,
                     ..
                 } = subcoin_service::new_node(subcoin_service::SubcoinConfiguration {
                     network: bitcoin::Network::Bitcoin,
                     config: &config,
+                    block_execution_strategy,
                     no_hardware_benchmarks,
                     storage_monitor,
                 })?;
@@ -93,7 +96,10 @@ pub fn run() -> sc_cli::Result<()> {
                         is_major_syncing,
                     )
                 });
-                Ok((import_blocks_cmd.run(client, data_dir), task_manager))
+                Ok((
+                    import_blocks_cmd.run(client, block_executor, data_dir),
+                    task_manager,
+                ))
             })
         }
         Command::CheckBlock(cmd) => {

--- a/crates/subcoin-node/src/commands/import_blocks.rs
+++ b/crates/subcoin-node/src/commands/import_blocks.rs
@@ -71,7 +71,12 @@ impl ImportBlocksCmd {
     }
 
     /// Run the import-blocks command
-    pub async fn run(&self, client: Arc<FullClient>, data_dir: PathBuf) -> sc_cli::Result<()> {
+    pub async fn run(
+        &self,
+        client: Arc<FullClient>,
+        block_executor: Box<dyn sc_consensus_nakamoto::BlockExecutor<OpaqueBlock>>,
+        data_dir: PathBuf,
+    ) -> sc_cli::Result<()> {
         let from = (client.info().best_number + 1) as usize;
 
         let bitcoind_backend = BitcoinBackend::new(&data_dir);
@@ -104,6 +109,7 @@ impl ImportBlocksCmd {
                     execute_block: self.execute_block,
                 },
                 Arc::new(crate::CoinStorageKey),
+                block_executor,
             );
 
         for index in from..=to {

--- a/crates/subcoin-service/Cargo.toml
+++ b/crates/subcoin-service/Cargo.toml
@@ -18,6 +18,7 @@ sc-client-api = { workspace = true }
 sc-consensus = { workspace = true }
 sc-consensus-nakamoto = { workspace = true }
 sc-executor = { workspace = true }
+sc-fast-sync-backend = { workspace = true }
 sc-network = { workspace = true }
 sc-rpc = { workspace = true }
 # `test-helpers` for the exposed Client type.
@@ -38,3 +39,9 @@ sp-trie = { workspace = true }
 subcoin-primitives = { workspace = true }
 subcoin-runtime = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+sp-tracing = { workspace = true }
+subcoin-test-service = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/subcoin-service/src/block_executor.rs
+++ b/crates/subcoin-service/src/block_executor.rs
@@ -1,0 +1,386 @@
+use crate::{
+    initialize_genesis_block_hash_mapping, BitcoinExecutorDispatch, CoinStorageKey, FullBackend,
+    FullClient, GenesisBlockBuilder, InMemoryBackend, InMemoryClient, TransactionAdapter,
+};
+use sc_client_api::{Backend, HeaderBackend, StateBackend, StorageProvider};
+use sc_consensus_nakamoto::{
+    BlockExecutionStrategy, BlockExecutor, ClientContext, ExecutionBackend,
+};
+use sc_executor::NativeElseWasmExecutor;
+use sc_service::{Configuration, Error as ServiceError, SpawnTaskHandle};
+use sp_runtime::traits::{Block as BlockT, HashingFor, Header as HeaderT};
+use sp_runtime::StateVersion;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use subcoin_runtime::interface::OpaqueBlock as Block;
+
+fn runtime_hash_and_code(
+    backend: &Arc<FullBackend>,
+    block_hash: <Block as BlockT>::Hash,
+) -> (<Block as BlockT>::Hash, Vec<u8>) {
+    let state = backend.state_at(block_hash).expect("State not found");
+
+    let hash = state
+        .storage_hash(sp_core::storage::well_known_keys::CODE)
+        .ok()
+        .flatten()
+        .expect("`:code` hash not found");
+
+    let code = state
+        .storage(sp_core::storage::well_known_keys::CODE)
+        .ok()
+        .flatten()
+        .expect("code not found");
+
+    (hash, code)
+}
+
+fn new_in_memory_backend(
+    client: &Arc<FullClient>,
+    backend: &Arc<FullBackend>,
+) -> Result<(InMemoryBackend, bool), ServiceError> {
+    let info = client.info();
+
+    let best_number = info.best_number;
+    let best_hash = info.best_hash;
+
+    // Read the runtime code from the disk backend and use them to initialize the fast-sync
+    // backend.
+    let (runtime_hash, runtime_code) = runtime_hash_and_code(backend, best_hash);
+
+    let mut in_memory_backend = sc_fast_sync_backend::Backend::new(runtime_hash, runtime_code);
+
+    let mut is_refresh = true;
+
+    if best_number > 0u32 {
+        tracing::info!(
+            "Initializing in-memory backend from state at #{best_number},{best_hash}.{}",
+            if best_number > 150_000 {
+                " Please wait. This might take some time depending on the state size."
+            } else {
+                ""
+            }
+        );
+
+        let now = std::time::Instant::now();
+
+        let top = client
+            .storage_pairs(info.best_hash, None, None)?
+            .map(|(key, data)| (key.0, data.0))
+            .collect::<BTreeMap<_, _>>();
+
+        let storage = sp_storage::Storage {
+            top,
+            ..Default::default()
+        };
+
+        let chain_state: sp_state_machine::InMemoryBackend<HashingFor<Block>> =
+            (storage, StateVersion::V0).into();
+
+        let best_header = client.header(best_hash)?.expect("Best header must exist");
+
+        let state_root = *best_header.state_root();
+
+        in_memory_backend.initialize(best_header, info.genesis_hash, chain_state);
+
+        assert_eq!(
+            state_root,
+            in_memory_backend.storage_root(),
+            "Storage root of initialized in-memory backend must match the state root"
+        );
+
+        is_refresh = false;
+
+        tracing::info!(
+            "In memory backend initialized successfully in {}ms",
+            now.elapsed().as_millis()
+        );
+    }
+
+    Ok((in_memory_backend, is_refresh))
+}
+
+pub(super) fn new_in_memory_client(
+    client: Arc<FullClient>,
+    backend: Arc<FullBackend>,
+    executor: NativeElseWasmExecutor<BitcoinExecutorDispatch>,
+    bitcoin_network: bitcoin::Network,
+    spawn_handle: SpawnTaskHandle,
+    config: &Configuration,
+) -> Result<Arc<InMemoryClient>, ServiceError> {
+    let (in_memory_backend, is_refresh) = new_in_memory_backend(&client, &backend)?;
+    let in_memory_backend = Arc::new(in_memory_backend);
+
+    let no_genesis = !is_refresh;
+
+    let genesis_block_builder = GenesisBlockBuilder::<_, _, _, TransactionAdapter>::new(
+        bitcoin_network,
+        config.chain_spec.as_storage_builder(),
+        !no_genesis,
+        in_memory_backend.clone(),
+        executor.clone(),
+    )?;
+
+    let client_config = sc_service::ClientConfig {
+        offchain_worker_enabled: config.offchain_worker.enabled,
+        offchain_indexing_api: config.offchain_worker.indexing_enabled,
+        wasm_runtime_overrides: config.wasm_runtime_overrides.clone(),
+        no_genesis,
+        wasm_runtime_substitutes: HashMap::new(),
+        enable_import_proof_recording: false,
+    };
+
+    let in_memory_client = sc_service::client::new_with_backend(
+        in_memory_backend,
+        executor,
+        genesis_block_builder,
+        Box::new(spawn_handle),
+        None,
+        None,
+        client_config,
+    )?;
+
+    initialize_genesis_block_hash_mapping(&in_memory_client, bitcoin_network);
+
+    Ok(Arc::new(in_memory_client))
+}
+
+fn new_box<T: BlockExecutor<Block> + 'static>(processor: T) -> Box<dyn BlockExecutor<Block>> {
+    Box::new(processor) as Box<dyn BlockExecutor<Block>>
+}
+
+pub(super) fn new_block_executor(
+    client: Arc<FullClient>,
+    block_execution_strategy: BlockExecutionStrategy,
+    in_memory_client: Option<Arc<InMemoryClient>>,
+) -> Box<dyn BlockExecutor<Block>> {
+    use sc_consensus_nakamoto::{
+        BenchmarkAllExecutor, BenchmarkRuntimeBlockExecutor, OffRuntimeBlockExecutor,
+        RuntimeBlockExecutor,
+    };
+
+    match block_execution_strategy {
+        BlockExecutionStrategy::RuntimeExecution(exec_backend) => match exec_backend {
+            ExecutionBackend::Disk => new_box(RuntimeBlockExecutor::new(
+                client.clone(),
+                ClientContext::<FullClient>::Disk,
+            )),
+            ExecutionBackend::InMemory => {
+                let in_memory_client = in_memory_client.expect("In memory create must be created");
+                new_box(RuntimeBlockExecutor::new(
+                    in_memory_client.clone(),
+                    ClientContext::InMemory(in_memory_client),
+                ))
+            }
+        },
+        BlockExecutionStrategy::OffRuntimeExecution(exec_backend) => match exec_backend {
+            ExecutionBackend::Disk => {
+                new_box(
+                    OffRuntimeBlockExecutor::<_, _, _, TransactionAdapter, _>::new(
+                        client.clone(),
+                        ClientContext::<FullClient>::Disk,
+                        Arc::new(CoinStorageKey),
+                    ),
+                )
+            }
+            ExecutionBackend::InMemory => {
+                let in_memory_client = in_memory_client.expect("In memory create must be created");
+                new_box(
+                    OffRuntimeBlockExecutor::<_, _, _, TransactionAdapter, _>::new(
+                        in_memory_client.clone(),
+                        ClientContext::InMemory(in_memory_client),
+                        Arc::new(CoinStorageKey),
+                    ),
+                )
+            }
+        },
+        BlockExecutionStrategy::BenchmarkRuntimeExecution => {
+            let disk_runtime_block_executor = new_box(RuntimeBlockExecutor::new(
+                client.clone(),
+                ClientContext::<FullClient>::Disk,
+            ));
+            let in_memory_client = in_memory_client.expect("In memory create must be created");
+            let in_memory_runtime_block_executor = new_box(RuntimeBlockExecutor::new(
+                in_memory_client.clone(),
+                ClientContext::InMemory(in_memory_client),
+            ));
+            new_box(BenchmarkRuntimeBlockExecutor::new(
+                disk_runtime_block_executor,
+                in_memory_runtime_block_executor,
+            ))
+        }
+        BlockExecutionStrategy::BenchmarkAll => {
+            let disk_runtime_block_executor =
+                RuntimeBlockExecutor::new(client.clone(), ClientContext::<FullClient>::Disk);
+            let in_memory_client = in_memory_client.expect("In memory create must be created");
+            let in_memory_runtime_block_executor = RuntimeBlockExecutor::new(
+                in_memory_client.clone(),
+                ClientContext::InMemory(in_memory_client.clone()),
+            );
+            let disk_off_runtime_block_executor =
+                OffRuntimeBlockExecutor::<_, _, _, TransactionAdapter, _>::new(
+                    client.clone(),
+                    ClientContext::<FullClient>::Disk,
+                    Arc::new(CoinStorageKey),
+                );
+            let in_memory_off_runtime_block_executor =
+                OffRuntimeBlockExecutor::<_, _, _, TransactionAdapter, _>::new(
+                    in_memory_client.clone(),
+                    ClientContext::InMemory(in_memory_client),
+                    Arc::new(CoinStorageKey),
+                );
+            new_box(BenchmarkAllExecutor::new(
+                disk_runtime_block_executor,
+                in_memory_runtime_block_executor,
+                disk_off_runtime_block_executor,
+                in_memory_off_runtime_block_executor,
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{new_node, NodeComponents, SubcoinConfiguration};
+    use sc_consensus_nakamoto::{
+        BitcoinBlockImport, BitcoinBlockImporter, BlockVerification, ImportConfig, ImportStatus,
+    };
+    use sc_service::config::DatabaseSource;
+    use sc_service::BasePath;
+    use subcoin_runtime::Header;
+    use subcoin_test_service::block_data;
+    use tokio::runtime::Handle;
+
+    async fn run_with_runtime_disk_executor(config: &Configuration, up_to: u32) -> Header {
+        let NodeComponents {
+            block_executor,
+            client,
+            ..
+        } = new_node(SubcoinConfiguration {
+            network: bitcoin::Network::Bitcoin,
+            block_execution_strategy: BlockExecutionStrategy::runtime_disk(),
+            config,
+            no_hardware_benchmarks: true,
+            storage_monitor: Default::default(),
+        })
+        .expect("Failed to create node");
+
+        let mut bitcoin_block_import = BitcoinBlockImporter::<_, _, _, _, TransactionAdapter>::new(
+            client.clone(),
+            client.clone(),
+            ImportConfig {
+                network: bitcoin::Network::Bitcoin,
+                block_verification: BlockVerification::None,
+                execute_block: true,
+            },
+            Arc::new(CoinStorageKey),
+            block_executor,
+        );
+
+        let test_blocks = block_data();
+        for block_number in 1..=up_to {
+            let block = test_blocks[block_number as usize].clone();
+            let import_status = bitcoin_block_import.import_block(block).await.unwrap();
+            assert!(matches!(import_status, ImportStatus::Imported { .. }));
+        }
+
+        client.header(client.info().best_hash).unwrap().unwrap()
+    }
+
+    #[tokio::test]
+    async fn off_runtime_in_memory_executor_should_produce_same_result_as_runtime_disk_executor() {
+        sp_tracing::try_init_simple();
+
+        let runtime_handle = Handle::current();
+
+        let network = bitcoin::Network::Bitcoin;
+
+        let mut config = subcoin_test_service::test_configuration(runtime_handle);
+
+        let expected_header3 = run_with_runtime_disk_executor(&config, 3).await;
+
+        // Use a different data path as the client above may still hold the database file.
+        let tmp = tempfile::tempdir().unwrap();
+        let base_path = BasePath::new(tmp.path());
+        let root = base_path.path().to_path_buf();
+        config.database = DatabaseSource::ParityDb {
+            path: root.join("db"),
+        };
+        config.data_path = base_path.path().into();
+        config.base_path = base_path;
+
+        let NodeComponents {
+            block_executor,
+            client,
+            backend,
+            task_manager,
+            executor,
+            ..
+        } = new_node(SubcoinConfiguration {
+            network,
+            block_execution_strategy: BlockExecutionStrategy::runtime_disk(),
+            config: &config,
+            no_hardware_benchmarks: true,
+            storage_monitor: Default::default(),
+        })
+        .expect("Failed to create node");
+
+        let mut bitcoin_block_import = BitcoinBlockImporter::<_, _, _, _, TransactionAdapter>::new(
+            client.clone(),
+            client.clone(),
+            ImportConfig {
+                network,
+                block_verification: BlockVerification::None,
+                execute_block: true,
+            },
+            Arc::new(CoinStorageKey),
+            block_executor,
+        );
+
+        let test_blocks = block_data();
+
+        bitcoin_block_import
+            .import_block(test_blocks[1].clone())
+            .await
+            .unwrap();
+
+        let in_mem_client = new_in_memory_client(
+            client.clone(),
+            backend.clone(),
+            executor.clone(),
+            network,
+            task_manager.spawn_handle(),
+            &config,
+        )
+        .unwrap();
+
+        let block_executor = new_block_executor(
+            client.clone(),
+            BlockExecutionStrategy::off_runtime_in_memory(),
+            Some(in_mem_client),
+        );
+
+        // Set the block executor using in memory backend initialized from the latest state in the
+        // disk backend.
+        bitcoin_block_import.set_block_executor(block_executor);
+
+        let import_status = bitcoin_block_import
+            .import_block(test_blocks[2].clone())
+            .await
+            .unwrap();
+        assert!(matches!(import_status, ImportStatus::Imported { .. }));
+
+        let import_status = bitcoin_block_import
+            .import_block(test_blocks[3].clone())
+            .await
+            .unwrap();
+        assert!(matches!(import_status, ImportStatus::Imported { .. }));
+
+        let best_header = client.header(client.info().best_hash).unwrap().unwrap();
+
+        assert_eq!(best_header, expected_header3);
+
+        let _ = tmp.close();
+    }
+}

--- a/crates/subcoin-service/src/lib.rs
+++ b/crates/subcoin-service/src/lib.rs
@@ -274,7 +274,7 @@ pub fn new_node(config: SubcoinConfiguration) -> Result<NodeComponents, ServiceE
                 executor.clone(),
                 bitcoin_network,
                 task_manager.spawn_handle(),
-                &config,
+                config,
             )?)
         } else {
             None

--- a/crates/subcoin-service/src/lib.rs
+++ b/crates/subcoin-service/src/lib.rs
@@ -2,17 +2,20 @@
 
 #![allow(deprecated)]
 
+mod block_executor;
 pub mod chain_spec;
 mod genesis_block_builder;
 mod transaction_adapter;
 
 use bitcoin::hashes::Hash;
+use block_executor::{new_block_executor, new_in_memory_client};
 use frame_benchmarking_cli::SUBSTRATE_REFERENCE_HARDWARE;
 use futures::StreamExt;
 use genesis_block_builder::GenesisBlockBuilder;
 use sc_client_api::{AuxStore, BlockchainEvents, Finalizer, HeaderBackend};
 use sc_consensus::import_queue::BasicQueue;
 use sc_consensus::{BlockImportParams, Verifier};
+use sc_consensus_nakamoto::{BlockExecutionStrategy, BlockExecutor};
 use sc_executor::NativeElseWasmExecutor;
 use sc_network::PeerId;
 use sc_service::error::Error as ServiceError;
@@ -40,6 +43,19 @@ pub type FullClient =
     sc_service::TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<BitcoinExecutorDispatch>>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
+
+/// In memory client type.
+pub type InMemoryClient = sc_service::client::Client<
+    InMemoryBackend,
+    sc_service::LocalCallExecutor<
+        Block,
+        sc_fast_sync_backend::Backend<Block>,
+        NativeElseWasmExecutor<BitcoinExecutorDispatch>,
+    >,
+    Block,
+    RuntimeApi,
+>;
+pub type InMemoryBackend = sc_fast_sync_backend::Backend<Block>;
 
 pub struct BitcoinExecutorDispatch;
 
@@ -139,6 +155,14 @@ async fn build_system_rpc_future<Block, Client>(
     }
 }
 
+pub struct CoinStorageKey;
+
+impl subcoin_primitives::CoinStorageKey for CoinStorageKey {
+    fn storage_key(&self, txid: bitcoin::Txid, vout: u32) -> Vec<u8> {
+        pallet_bitcoin::coin_storage_key::<subcoin_runtime::Runtime>(txid, vout)
+    }
+}
+
 /// Subcoin node components.
 pub struct NodeComponents {
     /// Client.
@@ -149,6 +173,8 @@ pub struct NodeComponents {
     pub executor: NativeElseWasmExecutor<BitcoinExecutorDispatch>,
     /// Task manager.
     pub task_manager: TaskManager,
+    /// Block processor used in the block import pipeline.
+    pub block_executor: Box<dyn BlockExecutor<Block>>,
     /// TODO: useless, remove later?
     pub system_rpc_tx: TracingUnboundedSender<sc_rpc::system::Request<Block>>,
 }
@@ -157,6 +183,7 @@ pub struct NodeComponents {
 pub struct SubcoinConfiguration<'a> {
     pub network: bitcoin::Network,
     pub config: &'a Configuration,
+    pub block_execution_strategy: BlockExecutionStrategy,
     pub no_hardware_benchmarks: bool,
     pub storage_monitor: sc_storage_monitor::StorageMonitorParams,
 }
@@ -192,6 +219,7 @@ pub fn new_node(config: SubcoinConfiguration) -> Result<NodeComponents, ServiceE
     let SubcoinConfiguration {
         network: bitcoin_network,
         config,
+        block_execution_strategy,
         no_hardware_benchmarks,
         storage_monitor,
     } = config;
@@ -234,6 +262,24 @@ pub fn new_node(config: SubcoinConfiguration) -> Result<NodeComponents, ServiceE
     initialize_genesis_block_hash_mapping(&client, bitcoin_network);
 
     let client = Arc::new(client);
+
+    let should_create_in_memory_client = block_execution_strategy.in_memory_backend_used();
+    let block_executor = new_block_executor(
+        client.clone(),
+        block_execution_strategy,
+        if should_create_in_memory_client {
+            Some(new_in_memory_client(
+                client.clone(),
+                backend.clone(),
+                executor.clone(),
+                bitcoin_network,
+                task_manager.spawn_handle(),
+                &config,
+            )?)
+        } else {
+            None
+        },
+    );
 
     let mut telemetry = telemetry.map(|(worker, telemetry)| {
         task_manager
@@ -300,6 +346,7 @@ pub fn new_node(config: SubcoinConfiguration) -> Result<NodeComponents, ServiceE
         backend,
         executor,
         task_manager,
+        block_executor,
         system_rpc_tx,
     })
 }

--- a/crates/subcoin-test-service/Cargo.toml
+++ b/crates/subcoin-test-service/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "subcoin-test-service"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+bitcoin = { workspace = true }
+serde_json = { workspace = true }
+sc-consensus-nakamoto = { workspace = true }
+sc-service = { workspace = true }
+sp-keyring = { workspace = true }
+subcoin-runtime = { workspace = true }
+subcoin-service = { workspace = true }
+tokio = { workspace = true }

--- a/crates/subcoin-test-service/src/lib.rs
+++ b/crates/subcoin-test-service/src/lib.rs
@@ -106,5 +106,7 @@ pub fn new_test_node(tokio_handle: tokio::runtime::Handle) -> Result<NodeCompone
         network: bitcoin::Network::Bitcoin,
         block_execution_strategy: BlockExecutionStrategy::RuntimeExecution(ExecutionBackend::Disk),
         config: &config,
+        no_hardware_benchmarks: true,
+        storage_monitor: Default::default(),
     })
 }

--- a/crates/subcoin-test-service/src/lib.rs
+++ b/crates/subcoin-test-service/src/lib.rs
@@ -1,0 +1,110 @@
+use bitcoin::consensus::Decodable;
+use bitcoin::hex::FromHex;
+use bitcoin::Block;
+use sc_consensus_nakamoto::{BlockExecutionStrategy, ExecutionBackend};
+use sc_service::config::{
+    BlocksPruning, DatabaseSource, KeystoreConfig, NetworkConfiguration, OffchainWorkerConfig,
+    PruningMode, RpcBatchRequestConfig, WasmExecutionMethod, WasmtimeInstantiationStrategy,
+};
+use sc_service::error::Error as ServiceError;
+use sc_service::{BasePath, Configuration, Role};
+use sp_keyring::sr25519::Keyring as Sr25519Keyring;
+use subcoin_service::{NodeComponents, SubcoinConfiguration};
+
+fn decode_raw_block(hex_str: &str) -> Block {
+    let data = Vec::<u8>::from_hex(hex_str).expect("Failed to convert hex str");
+    Block::consensus_decode(&mut data.as_slice()).expect("Failed to convert hex data to Block")
+}
+
+pub fn block_data() -> Vec<Block> {
+    // genesis block
+    let block0 = decode_raw_block("0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000");
+    // https://webbtc.com/block/00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048
+    // height 1
+    let block1 = decode_raw_block("010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e362990101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000");
+    // https://webbtc.com/block/000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd.hex
+    // height 2
+    let block2  = decode_raw_block("010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5fdcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff001d08d2bd610101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d010bffffffff0100f2052a010000004341047211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385237d92167c13e236446b417ab79a0fcae412ae3316b77ac00000000");
+    // https://webbtc.com/block/0000000082b5015589a3fdf2d4baff403e6f0be035a5d9742c1cae6295464449.hex
+    // height 3
+    let block3 = decode_raw_block("01000000bddd99ccfda39da1b108ce1a5d70038d0a967bacb68b6b63065f626a0000000044f672226090d85db9a9f2fbfe5f0f9609b387af7be5b7fbb7a1767c831c9e995dbe6649ffff001d05e0ed6d0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d010effffffff0100f2052a0100000043410494b9d3e76c5b1629ecf97fff95d7a4bbdac87cc26099ada28066c6ff1eb9191223cd897194a08d0c2726c5747f1db49e8cf90e75dc3e3550ae9b30086f3cd5aaac00000000");
+    vec![block0, block1, block2, block3]
+}
+
+pub fn test_configuration(tokio_handle: tokio::runtime::Handle) -> Configuration {
+    let base_path = BasePath::new_temp_dir()
+        .expect("getting the base path of a temporary path doesn't fail; qed");
+    let root = base_path.path().to_path_buf();
+
+    let network_config = NetworkConfiguration::new(
+        Sr25519Keyring::Alice.to_seed(),
+        "network/test/0.1",
+        Default::default(),
+        None,
+    );
+
+    let spec = subcoin_service::chain_spec::config(bitcoin::Network::Bitcoin)
+        .expect("Failed to create chain spec");
+
+    Configuration {
+        impl_name: "subcoin-test-node".to_string(),
+        impl_version: "1.0".to_string(),
+        role: Role::Full,
+        tokio_handle,
+        transaction_pool: Default::default(),
+        network: network_config,
+        keystore: KeystoreConfig::InMemory,
+        database: DatabaseSource::ParityDb {
+            path: root.join("db"),
+        },
+        trie_cache_maximum_size: Some(64 * 1024 * 1024),
+        state_pruning: Some(PruningMode::ArchiveAll),
+        blocks_pruning: BlocksPruning::KeepAll,
+        chain_spec: Box::new(spec),
+        wasm_method: WasmExecutionMethod::Compiled {
+            instantiation_strategy: WasmtimeInstantiationStrategy::PoolingCopyOnWrite,
+        },
+        rpc_addr: None,
+        rpc_max_connections: Default::default(),
+        rpc_cors: None,
+        rpc_methods: Default::default(),
+        rpc_max_request_size: Default::default(),
+        rpc_max_response_size: Default::default(),
+        rpc_id_provider: Default::default(),
+        rpc_max_subs_per_conn: Default::default(),
+        rpc_port: 9944,
+        rpc_message_buffer_capacity: Default::default(),
+        rpc_batch_config: RpcBatchRequestConfig::Unlimited,
+        rpc_rate_limit: None,
+        rpc_rate_limit_whitelisted_ips: Default::default(),
+        rpc_rate_limit_trust_proxy_headers: Default::default(),
+        prometheus_config: None,
+        telemetry_endpoints: None,
+        default_heap_pages: None,
+        offchain_worker: OffchainWorkerConfig {
+            enabled: true,
+            indexing_enabled: false,
+        },
+        force_authoring: false,
+        disable_grandpa: false,
+        dev_key_seed: Some(Sr25519Keyring::Alice.to_seed()),
+        tracing_targets: None,
+        tracing_receiver: Default::default(),
+        max_runtime_instances: 8,
+        runtime_cache_size: 2,
+        announce_block: true,
+        data_path: base_path.path().into(),
+        base_path,
+        informant_output_format: Default::default(),
+        wasm_runtime_overrides: None,
+    }
+}
+
+pub fn new_test_node(tokio_handle: tokio::runtime::Handle) -> Result<NodeComponents, ServiceError> {
+    let config = test_configuration(tokio_handle);
+    subcoin_service::new_node(SubcoinConfiguration {
+        network: bitcoin::Network::Bitcoin,
+        block_execution_strategy: BlockExecutionStrategy::RuntimeExecution(ExecutionBackend::Disk),
+        config: &config,
+    })
+}


### PR DESCRIPTION
This PR introduces various block execution strategies, basically the different combo of state backend (disk/in-memory) and block execution (runtime/off-runtime).

The initial idea was to leverage the in-memory backend for faster state root computation. However, the final performance boost on block execution was roughly less than 10x, with the memory usage skyrocketing to 43GB when the chain grows to block 430000+. The number is much lower than my expectation since the read/write of disk versus memory could be up to 1000x. This experiment of block execution optimization does not produce a satisfying full sync performance from genesis, we still need to dig into it.

There are a few leftovers that can be worked on later.