### PR TITLE
Add Dockerfile and build images for Linux/amd64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Log into registry
         uses: docker/login-action@v3
         with:
@@ -65,6 +73,8 @@ jobs:
         with:
           file: Dockerfile${{ matrix.platform.dockerfile-suffix }}
           platforms: ${{ matrix.platform.arch }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,76 @@
+# This action enables building container images for subcoin node.
+name: Docker build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - docker
+      - 'release/**'
+    tags:
+      - '**'
+
+jobs:
+  container-linux:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
+    strategy:
+      matrix:
+        platform:
+          - arch: linux/amd64
+            profile: production
+            suffix: ubuntu-x86_64-${{ github.ref_name }}
+            image-suffix: ''
+            dockerfile-suffix: ''
+          # - arch: linux/arm64
+            # profile: production
+            # suffix: ubuntu-aarch64-${{ github.ref_name }}
+            # image-suffix: '-aarch64'
+            # dockerfile-suffix: '.aarch64'
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/subcoin-project/subcoin
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            type=sha
+          flavor: |
+            latest=false
+            suffix=${{ matrix.platform.image-suffix }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile${{ matrix.platform.dockerfile-suffix }}
+          platforms: ${{ matrix.platform.arch }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
+            PROFILE=${{ matrix.platform.profile }}
+
+      - name: Image digest
+        run: echo ${{ steps.build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - docker
       - 'release/**'
     tags:
       - '**'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ jobs:
             suffix: ubuntu-x86_64-${{ github.ref_name }}
             image-suffix: ''
             dockerfile-suffix: ''
+          # TODO: https://github.com/subcoin-project/subcoin/issues/13
           # - arch: linux/arm64
             # profile: production
             # suffix: ubuntu-aarch64-${{ github.ref_name }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,12 +118,10 @@ subcoin-service = { path = "crates/subcoin-service" }
 subcoin-test-service = { path = "crates/subcoin-test-service" }
 
 [profile.release]
-debug = true
 panic = "abort"
 
 [profile.production]
 inherits = "release"
-debug = false
 # Sacrifice compile speed for execution speed by using optimization flags:
 lto = "fat"       # https://doc.rust-lang.org/rustc/linker-plugin-lto.html
 codegen-units = 1 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# This is a base image to build Subcoin node
+FROM ubuntu:22.04 AS builder
+
+ARG PROFILE=production
+ARG SUBSTRATE_CLI_GIT_COMMIT_HASH
+
+# Incremental compilation here isn't helpful
+ENV CARGO_INCREMENTAL=0
+
+WORKDIR /src
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        clang \
+        cmake \
+        curl \
+        git \
+        llvm \
+        protobuf-compiler \
+        make && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# Copy the source code
+COPY . .
+
+# Compile the binary and move it to /subcoin.
+RUN /root/.cargo/bin/cargo build \
+    --locked \
+    --bin subcoin \
+    --profile=$PROFILE \
+    --target $(uname -p)-unknown-linux-gnu && \
+    mv target/*/*/subcoin /subcoin && \
+    rm -rf target
+
+# This is the 2nd stage: a very small image where we copy the binary.
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.source="https://github.com/subcoin-project/subcoin"
+LABEL org.opencontainers.image.description="Multistage Docker image for Subcoin Node"
+
+# Copy the node binary.
+COPY --from=builder /subcoin /subcoin
+
+RUN mkdir /node-data && chown nobody:nogroup /node-data
+
+VOLUME ["/node-data"]
+
+USER nobody:nogroup
+
+EXPOSE 30333 9933 9944 9615
+
+ENTRYPOINT ["/subcoin"]


### PR DESCRIPTION
This PR adds Dockerfile for Linux/amd64, Linux/arm64 is not available at present due to the build being too low to be aborted (https://github.com/subcoin-project/subcoin/actions/runs/9889668313/attempts/1), which may be resolved when https://github.com/orgs/community/discussions/19197 is closed.