### PR TITLE
ci: add Linux arm64 Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
       - '**'
 
 jobs:
-  container-linux:
+  container-linux-amd64:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -20,18 +20,11 @@ jobs:
       matrix:
         build:
           - arch: linux/amd64
-            image: subcoin # Subcoin Node
-            suffix: ubuntu-x86_64-${{ github.ref_name }}
+            image: subcoin
             image-suffix: ''
           - arch: linux/amd64
             image: snapcake
-            suffix: ubuntu-x86_64-${{ github.ref_name }}
             image-suffix: ''
-          # TODO: https://github.com/subcoin-project/subcoin/issues/13
-          # - arch: linux/arm64
-            # suffix: ubuntu-aarch64-${{ github.ref_name }}
-            # image-suffix: '-aarch64'
-            # dockerfile-suffix: '.aarch64'
 
     steps:
       - name: Set up QEMU
@@ -82,6 +75,71 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Added to prevent tons of untagged images in GHCR.
           # See: https://github.com/docker/build-push-action/issues/894
+          provenance: false
+          build-args: |
+            SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}
+
+      - name: Image digest
+        run: echo ${{ steps.build.outputs.digest }}
+
+  container-linux-arm64:
+    runs-on: ubuntu-22.04-arm
+    permissions:
+      contents: write
+      packages: write
+    strategy:
+      matrix:
+        build:
+          - arch: linux/arm64
+            image: subcoin
+            image-suffix: '-arm64'
+          - arch: linux/arm64
+            image: snapcake
+            image-suffix: '-arm64'
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-arm64-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-buildx-
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/subcoin-project/${{ matrix.build.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+          flavor: |
+            latest=false
+            suffix=${{ matrix.build.image-suffix }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          file: docker/${{ matrix.build.image }}.Dockerfile
+          platforms: ${{ matrix.build.arch }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           provenance: false
           build-args: |
             SUBSTRATE_CLI_GIT_COMMIT_HASH=${{ github.sha }}


### PR DESCRIPTION
## Summary

- Add support for building arm64 Docker images using GitHub's `ubuntu-22.04-arm` runners
- The arm64 images will be tagged with `-arm64` suffix (e.g., `ghcr.io/subcoin-project/subcoin:main-arm64`)
- Both `subcoin` and `snapcake` images will be built for arm64

GitHub's arm64 hosted runners are [now generally available](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/) for public repositories.

Closes #13

## Test plan

- [ ] Merge and verify the Docker workflow runs successfully for arm64
- [ ] Pull and test the arm64 images on an ARM machine